### PR TITLE
Acid800 accuracy improvements + dual-region CI

### DIFF
--- a/packages/a8/package.json
+++ b/packages/a8/package.json
@@ -37,7 +37,7 @@
     "test:package": "publint",
     "boot": "node src/boot.ts",
     "acid800-tests": "node src/acid800-tests.ts",
-    "ci": "pnpm acid800-tests"
+    "ci": "pnpm acid800-tests && pnpm acid800-tests --pal"
   },
   "dependencies": {
     "@sfotty-pie/sfotty": "workspace:*",

--- a/packages/a8/src/acid800-tests.ts
+++ b/packages/a8/src/acid800-tests.ts
@@ -25,6 +25,7 @@ function runSuite(): Record<string, Status> {
 		[
 			join(HERE, "boot.ts"),
 			"--xe",
+			...(process.argv.includes("--pal") ? ["--pal"] : []),
 			"--os",
 			join(FIRMWARE, "AltirraOS XL-XE.rom"),
 			"--basic",

--- a/packages/a8/src/antic-gtia.ts
+++ b/packages/a8/src/antic-gtia.ts
@@ -1432,15 +1432,21 @@ export class AnticGtia implements Memory {
 			return false;
 		}
 
+		let base: number;
 		let offset: number;
 		if (this.verticalPmResolution === 1) {
+			// One-line resolution: PMBASE is 2K-aligned (bits 0-2 ignored).
+			base = (this.pmbase & 0xf8) * 256;
 			offset = 768;
 		} else {
+			// Two-line resolution: PMBASE is 1K-aligned (bits 0-1 ignored).
+			base = (this.pmbase & 0xfc) * 256;
 			offset = 384;
 		}
 
-		const addr = this.pmbase * 256 + offset;
-		this.#dmaRead(addr + Math.floor(this.vcount / this.verticalPmResolution));
+		this.#dmaRead(
+			base + offset + Math.floor(this.vcount / this.verticalPmResolution),
+		);
 
 		return true;
 	}
@@ -1450,15 +1456,21 @@ export class AnticGtia implements Memory {
 			return false;
 		}
 
+		let base: number;
 		let offset: number;
 		if (this.verticalPmResolution === 1) {
+			// One-line resolution: PMBASE is 2K-aligned (bits 0-2 ignored).
+			base = (this.pmbase & 0xf8) * 256;
 			offset = 1024 + n * 256;
 		} else {
+			// Two-line resolution: PMBASE is 1K-aligned (bits 0-1 ignored).
+			base = (this.pmbase & 0xfc) * 256;
 			offset = 512 + n * 128;
 		}
 
-		const addr = this.pmbase * 256 + offset;
-		this.#dmaRead(addr + Math.floor(this.vcount / this.verticalPmResolution));
+		this.#dmaRead(
+			base + offset + Math.floor(this.vcount / this.verticalPmResolution),
+		);
 
 		return true;
 	}

--- a/packages/a8/src/antic-gtia.ts
+++ b/packages/a8/src/antic-gtia.ts
@@ -1056,9 +1056,17 @@ export class AnticGtia implements Memory {
 		const x = i - 17 + 3;
 		const y = this.vcount - 8;
 
-		if (y < 0 || y >= 240 || x < 0 || x >= 94) {
+		if (y < 0 || y >= 240) {
 			return 0;
 		}
+
+		// A sprite triggered in the left horizontal blank still shifts its
+		// pixels into the visible region and collides there, so the shift
+		// registers must load and advance regardless of the horizontal window —
+		// only the output is blanked outside it. Gating the load on x (as a
+		// single early return did) dropped the whole sprite when it triggered
+		// in HBLANK, losing the pixels that spill into the visible area.
+		const visible = x >= 0 && x < 94;
 
 		const start = (this.hpos + 2) * 2 + pos;
 
@@ -1185,7 +1193,7 @@ export class AnticGtia implements Memory {
 			}
 		}
 
-		return result;
+		return visible ? result : 0;
 	}
 
 	// Get playfield and P/M outputs and detect collisions

--- a/packages/a8/src/antic-gtia.ts
+++ b/packages/a8/src/antic-gtia.ts
@@ -944,8 +944,24 @@ export class AnticGtia implements Memory {
 			// persist (the GTIA collision tests rely on that).
 			if (y < 224) {
 				if (i === 0 && this.enableMissiles) {
-					// TODO: VDELAY for missiles (bits 0-3)
-					this.grafM = busData;
+					// VDELAY bits 0-3 delay each missile independently, but
+					// grafM packs all four (M0=bits 0-1 .. M3=bits 6-7), so
+					// latch each pair on its own: a delayed missile updates only
+					// on odd scanlines, exactly like the per-player logic below.
+					let m = this.grafM;
+					if (isOddScanline || !(this.vdelay & 0x01)) {
+						m = (m & ~0x03) | (busData & 0x03);
+					}
+					if (isOddScanline || !(this.vdelay & 0x02)) {
+						m = (m & ~0x0c) | (busData & 0x0c);
+					}
+					if (isOddScanline || !(this.vdelay & 0x04)) {
+						m = (m & ~0x30) | (busData & 0x30);
+					}
+					if (isOddScanline || !(this.vdelay & 0x08)) {
+						m = (m & ~0xc0) | (busData & 0xc0);
+					}
+					this.grafM = m;
 				}
 
 				if (this.enablePlayers) {

--- a/packages/a8/src/boot.ts
+++ b/packages/a8/src/boot.ts
@@ -358,9 +358,17 @@ function reportHotspots(): void {
 async function run(): Promise<void> {
 	const ag = machine.anticGtia;
 
+	// Mirror the CPU's edge-triggered NMI latch host-side: a false→true
+	// transition on the NMI line arms a pending NMI that the CPU services at the
+	// next instruction boundary. Used only to gate host traps (below).
+	let prevNmi = false;
+	let nmiPending = false;
+
 	while (cycles < LIMIT) {
 		ag.beforeCpu();
 		machine.cycle();
+		if (ag.nmi && !prevNmi) nmiPending = true;
+		prevNmi = ag.nmi;
 		cpu.NMI = ag.nmi;
 		cpu.IRQ = machine.irq;
 		cpu.RDY = ag.rdy;
@@ -375,8 +383,15 @@ async function run(): Promise<void> {
 			seenPcs.add(cpu.PC);
 			if (trace) process.stderr.write(traceLine(cpu, peek) + "\n");
 
-			const trap = traps.get(cpu.PC);
-			if (trap) {
+			// A latched NMI is serviced at this boundary instead of executing
+			// the opcode at PC: the CPU pushes PC, vectors to the handler, then
+			// RTIs back here and re-DECODEs the same PC. Skip traps now so a
+			// side-effecting one (the E: PUTBYT stdout tee) fires once — after
+			// the RTI — rather than doubling the character.
+			const trap = nmiPending ? undefined : traps.get(cpu.PC);
+			if (nmiPending) {
+				nmiPending = false;
+			} else if (trap) {
 				try {
 					trapped = trap();
 				} catch (error) {

--- a/packages/a8/src/boot.ts
+++ b/packages/a8/src/boot.ts
@@ -16,7 +16,7 @@ import { Atari } from "./machine.ts";
 import { createSioHandler, SIOV } from "./sio.ts";
 import { buildBootDisk } from "./xex-boot.ts";
 
-// Usage: boot.ts --os <file> [--basic <file>] [--xl | --xe] [--trace] [--dump-frame] [file]
+// Usage: boot.ts --os <file> [--basic <file>] [--xl | --xe] [--pal] [--trace] [--dump-frame] [file]
 // `--os`/`--basic` are paths to the OS and BASIC ROM images. `file` is an XEX,
 // ATR, or cartridge image; like the web emulator's Load, booting a file is
 // boot-image semantics — the 800's BASIC cart comes out.
@@ -40,6 +40,7 @@ const osPath = flagValue("--os");
 const basicPath = flagValue("--basic");
 const xe = argv.includes("--xe");
 const xl = xe || argv.includes("--xl");
+const pal = argv.includes("--pal");
 // The positional file is the first non-flag arg that isn't a flag's value.
 const flagValueIndices = new Set(
 	["--os", "--basic", "--keys"]
@@ -79,6 +80,7 @@ const machine = new Atari({
 	os: loadRom(osPath, "--os"),
 	...(xl || !filePath ? { basic: loadRom(basicPath, "--basic") } : {}),
 	...(cartridge ? { cartridge } : {}),
+	...(pal ? { tvSystem: "pal" as const } : {}),
 });
 
 // --keys automation (e.g. Acid800): each time the program waits for a key — it

--- a/packages/a8/test/acid800/baseline.json
+++ b/packages/a8/test/acid800/baseline.json
@@ -30,7 +30,7 @@
 	"CPU: Timing": "pass",
 	"GTIA: Address mirroring": "pass",
 	"GTIA: CONSOL test": "pass",
-	"GTIA: Collision test": "fail",
+	"GTIA: Collision test": "pass",
 	"GTIA: Default value": "pass",
 	"GTIA: P/M retriggering": "pass",
 	"GTIA: Phantom PMG DMA": "fail",

--- a/packages/a8/test/acid800/baseline.json
+++ b/packages/a8/test/acid800/baseline.json
@@ -10,7 +10,7 @@
 	"ANTIC: HSCROL bug": "fail",
 	"ANTIC: Hires bug": "fail",
 	"ANTIC: Line buffering": "fail",
-	"ANTIC: NMIIST/NMIRES test": "pass",
+	"ANTIC: NMIST/NMIRES test": "pass",
 	"ANTIC: P/M graphics DMA": "fail",
 	"ANTIC: Playfield start timing": "fail",
 	"ANTIC: Playfield stop timing": "fail",

--- a/packages/a8/test/acid800/baseline.json
+++ b/packages/a8/test/acid800/baseline.json
@@ -38,7 +38,7 @@
 	"GTIA: Player resizing": "fail",
 	"GTIA: Psuedo mode E": "fail",
 	"GTIA: Special modes collision test": "fail",
-	"GTIA: Vertical delay": "fail",
+	"GTIA: Vertical delay": "pass",
 	"MMU: XL banking": "pass",
 	"PIA: Basic test": "pass",
 	"PIA: Interrupt control test": "pass",


### PR DESCRIPTION
Bundles several Acid800-driven emulation-accuracy fixes for the `a8` package, plus harness/CI work to run the conformance suite on both PAL and NTSC.

Scoreboard: **37 → 39** passing (GTIA 4/11 → 6/11).

## Changes
- **`fix(a8)`: mask PMBASE per resolution for P/M graphics DMA** — PMBASE is now aligned by resolution (2K one-line / 1K two-line). The P/M DMA fetch addressing is now correct (verified fetching the right bytes per scanline). Note: `antic_pmdma` itself stays red because it reads back through a GTIA mode-10 screen, which is unimplemented — this is a prerequisite for that test, not a flip.
- **`feat(a8)`: add `--pal` flag** to the boot harness and the Acid800 runner, so the suite (and manual testing) can run either TV system.
- **`fix(a8)`: gate boot traps on pending NMI** — the host `E: PUTBYT` stdout tee double-emitted a character when an NMI was serviced at the trapped instruction boundary (the CPU `RTI`s back and re-decodes the same PC). Mirrors the CPU's edge-triggered NMI latch host-side to fire the trap once. Fixes a region-dependent `NMIIST`/`NMIST` banner divergence and corrects the recorded baseline.
- **`fix(a8)`: register P/M collisions for sprites triggered in left HBLANK** — the shift registers now load/advance regardless of the horizontal window; only the output is blanked in HBLANK. Previously a sprite triggered at HPOS `$21` was dropped entirely, losing the pixels that spill into the visible region. Flips `GTIA: Collision test`.
- **`fix(a8)`: apply VDELAY to missiles per-missile** — `grafM` is now latched in 2-bit pairs so each missile's vertical delay is independent, mirroring the per-player logic. Flips `GTIA: Vertical delay`.
- **CI runs both regions** — the `a8` `ci` script now runs `acid800-tests` for NTSC and PAL against the same baseline, guarding against region divergence.

## Verification
- `pnpm run ci` (a8): both NTSC and PAL match baseline (39 pass / 18 fail / 1 skip).
- `pnpm test` (a8): typecheck, lint, 77 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)