### PR TITLE
fix(a8): latch P/M graphics across the full visible region (fixes River Raid PAL crash)

### DIFF
--- a/packages/a8/src/antic-gtia.test.ts
+++ b/packages/a8/src/antic-gtia.test.ts
@@ -288,3 +288,29 @@ test("direct GRAF writes survive when GRACTL has latching off", () => {
 	}
 	expect(ag.grafP0).toBe(0x20); // now the bus byte latches, like DMA
 });
+
+test("P/M graphics latch across the whole visible region, including the bottom band", () => {
+	// Regression: the latch was gated at y < 224, freezing player graphics over
+	// scan lines 232-247. Invisible on NTSC, but it corrupted River Raid's lower
+	// HUD on PAL (taller frame), leaking a stale P2<->P3 collision and crashing
+	// the plane. The latch must run for the full collision region (lines 8-247).
+	const ag = makeAnticGtia();
+	const frame = new Uint8Array(376 * 240);
+	ag.write(0xd01d, 0x02); // GRACTL: enable player-graphics latching
+
+	const latchOnLine = (vcount: number, busByte: number): number => {
+		ag.vcount = vcount;
+		ag.hpos = 0;
+		ag.grafP0 = 0x00;
+		for (let i = 0; i < 114; i++) {
+			ag.beforeCpu();
+			ag.afterCpu(frame, busByte);
+		}
+		return ag.grafP0;
+	};
+
+	// Bottom of the visible region (scan line 240): latches (used to freeze).
+	expect(latchOnLine(240, 0x5a)).toBe(0x5a);
+	// Vertical blank (scan line 248): no latch — graphics are off, per the AHRM.
+	expect(latchOnLine(248, 0x5a)).toBe(0x00);
+});

--- a/packages/a8/src/antic-gtia.ts
+++ b/packages/a8/src/antic-gtia.ts
@@ -966,8 +966,12 @@ export class AnticGtia implements Memory {
 
 			// The GRAF registers latch the bus during the P/M DMA slots only
 			// when GRACTL enables it — with GRACTL off, direct GRAF writes
-			// persist (the GTIA collision tests rely on that).
-			if (y < 224) {
+			// persist (the GTIA collision tests rely on that). The latch runs for
+			// the whole visible region (scan lines 8-247, i.e. y < 240): an
+			// earlier cut at y < 224 froze player graphics over the bottom 16
+			// lines, which is invisible on NTSC but corrupts the lower HUD on PAL
+			// (its taller frame puts content there) — River Raid's bug.
+			if (y < 240) {
 				if (i === 0 && this.enableMissiles) {
 					// VDELAY bits 0-3 delay each missile independently, but
 					// grafM packs all four (M0=bits 0-1 .. M3=bits 6-7), so


### PR DESCRIPTION
Fixes the long-standing River Raid PAL crash: the plane crashed ~1s after the first joystick input on PAL while NTSC played fine. This was the bug that motivated the trap-unification work (#5), and it's now diagnosed and fixed using that toolkit (headless host, bus observers, `onInstruction`, PNG screenshots).

## Root cause

In `antic-gtia.ts` `afterCpu`, the player/missile graphics DMA latch (`grafP*`/`grafM` ← bus byte) was gated by `if (y < 224)` — it stopped updating player graphics at scan line 232. But the P/M collision/render region is the full `y < 240` (scan lines 8–247, per the Altirra Hardware Reference Manual). So the latch must run there too.

## Why it only hit River Raid on PAL

RR draws its bottom HUD via player DMA. On NTSC the HUD digit finishes by ~scan line 226 (< 232), so the early cut was invisible. On PAL (312 vs 262 lines, taller frame) the digit sits at scan lines 231–237: the latch froze at 232 mid-digit, so `grafP2` stayed `$ff` all the way down. Players 2 and 3 (quad-width, hpos 89/68) then overlapped on every line to 247, producing a P2↔P3 collision that straddled RR's final `HITCLR` (line 237) and leaked into the next frame's first `P2PL` read — RR saw a stale "plane hit" and crashed. The PM graphics table was correct in both regions; only the latch failed to apply the `$00` below the digit.

## Fix

One line — `y < 224` → `y < 240` — plus a regression test in `antic-gtia.test.ts` ("bottom band") that latches a player on scan line 240 and confirms no latch in vertical blank (line 248). The test fails without the fix and passes with it.

This is **not** the deferred mid-scanline `pmoverlap`/`pmresize` work — a separate, simpler latch-region bug.

## Verification

- River Raid PAL: plane flies past the old crash point; NTSC: visibly unchanged (screenshots).
- Acid800: baseline unchanged both regions (39 pass / 18 fail / 1 skip).
- a8: 89 unit tests + typecheck + lint; a8-web: build + typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
