### PR TITLE
fix(a8-web): report logical emulated FPS, not RAF observation rate

### DIFF
--- a/apps/a8-web/src/host.ts
+++ b/apps/a8-web/src/host.ts
@@ -453,12 +453,11 @@ export class EmulatorHost {
 
 		let raf = 0;
 		let presented = -1;
-		let framesThisSecond = 0;
+		let framesAtSecondStart = this.#emulator.frameCount;
 		let secondStart = performance.now();
 		const present = () => {
 			if (this.#emulator.frameCount !== presented) {
 				presented = this.#emulator.frameCount;
-				framesThisSecond++;
 				const frame = this.#emulator.frame;
 				for (let i = 0; i < frame.length; i++) {
 					pixels[i] = palette[frame[i]!]!;
@@ -466,12 +465,24 @@ export class EmulatorHost {
 				context.putImageData(imageData, 0, 0);
 			}
 			this.crashed.value = this.#emulator.crashed; // dedup'd by the signal
-			// Sample the emulated frame rate about once a second.
+			// Sample the emulated frame rate about once a second. Measure the
+			// emulator's own frameCount delta over the elapsed wall clock, not
+			// how many distinct frames this RAF loop happened to observe — RAF
+			// coalesces under main-thread load and would undercount frames the
+			// emulator actually produced.
 			const now = performance.now();
 			const elapsed = now - secondStart;
-			if (elapsed >= 1000) {
-				this.fps.value = Math.round((framesThisSecond * 1000) / elapsed);
-				framesThisSecond = 0;
+			const frameCount = this.#emulator.frameCount;
+			if (frameCount < framesAtSecondStart) {
+				// The emulator was swapped (reboot/config change) and its
+				// frameCount reset — rebase the window rather than report a
+				// negative delta.
+				framesAtSecondStart = frameCount;
+				secondStart = now;
+			} else if (elapsed >= 1000) {
+				const frames = frameCount - framesAtSecondStart;
+				this.fps.value = Math.round((frames * 1000) / elapsed);
+				framesAtSecondStart = frameCount;
 				secondStart = now;
 			}
 			raf = requestAnimationFrame(present);


### PR DESCRIPTION
The FPS counter sampled the `requestAnimationFrame` present loop — counting one frame per RAF callback that observed a `frameCount` change. Under main-thread load RAF coalesces, so it credited at most one emulated frame per (delayed) callback and read consistently below target even though the emulator was keeping up (continuous audio, no slowdown).

Now it measures the emulator's own `frameCount` delta over the elapsed wall clock, reporting flips-per-second of the emulated machine (~60 NTSC / ~50 PAL) independent of display refresh or RAF cadence. A backwards jump in `frameCount` (emulator swap on reboot/config change) rebases the window instead of emitting a negative reading.

Verified honest down to 20× CPU throttling in DevTools — the counter tracks the real slowdown.