### PR TITLE
feat(a8-web): add muted turbo mode (run unthrottled)

### DIFF
--- a/apps/a8-web/src/commands.ts
+++ b/apps/a8-web/src/commands.ts
@@ -16,6 +16,11 @@ export const commands = {
 	RESUME: ({ host }) => host.resume(),
 	TOGGLE_PAUSE: ({ host }) => host.togglePause(),
 
+	// Turbo mode: run unthrottled (muted) vs. real time.
+	TURBO_MODE_ENABLE: ({ host }) => host.setTurboMode(true),
+	TURBO_MODE_DISABLE: ({ host }) => host.setTurboMode(false),
+	TURBO_MODE_TOGGLE: ({ host }) => host.toggleTurboMode(),
+
 	// Audio.
 	AUDIO_MUTE: ({ host }) => host.setMuted(true),
 	AUDIO_UNMUTE: ({ host }) => host.setMuted(false),
@@ -405,6 +410,10 @@ export const descriptions: Record<keyof typeof commands, string> = {
 	PAUSE: "Pause emulation",
 	RESUME: "Resume emulation",
 	TOGGLE_PAUSE: "Pause or resume emulation",
+
+	TURBO_MODE_ENABLE: "Enable turbo mode (run unthrottled, muted)",
+	TURBO_MODE_DISABLE: "Disable turbo mode (return to real-time speed)",
+	TURBO_MODE_TOGGLE: "Toggle turbo mode",
 
 	AUDIO_MUTE: "Mute audio",
 	AUDIO_UNMUTE: "Unmute audio",

--- a/apps/a8-web/src/emulator.ts
+++ b/apps/a8-web/src/emulator.ts
@@ -151,6 +151,7 @@ export class Emulator {
 	}
 
 	#running = false;
+	#turboMode = false;
 	#scanlines = 0;
 	#epoch = 0;
 
@@ -213,6 +214,20 @@ export class Emulator {
 		this.#running = false;
 	}
 
+	/**
+	 * Turbo mode: run as fast as the host allows, dropping both the audio
+	 * buffer gate and the wall-clock sleep so emulation is no longer pinned to
+	 * real time. Audio is suppressed while it's on (real-time playback can't
+	 * speed up without unbounded buffering). Toggling either way rebases the
+	 * wall clock and re-anchors the audio queue for a clean handoff.
+	 */
+	setTurboMode(enabled: boolean): void {
+		if (this.#turboMode === enabled) return;
+		this.#turboMode = enabled;
+		this.#audio?.clear();
+		this.#epoch = performance.now() - this.#scanlines * this.#msPerScanline;
+	}
+
 	/** Power cycle: cold-reset the machine and the CPU. */
 	coldStart(): void {
 		this.machine.reset(true);
@@ -238,6 +253,20 @@ export class Emulator {
 				await waitForVisible();
 				// The hidden interval is lost time, not work to replay.
 				this.#epoch = performance.now() - this.#scanlines * this.#msPerScanline;
+			}
+
+			if (this.#turboMode) {
+				// Unthrottled: run a whole emulated frame back-to-back, then
+				// yield a macrotask — the only thing turbo waits on, so input
+				// and the present loop still get a task turn. No sleep, no audio
+				// gate. One frame per yield self-bounds main-thread hold time.
+				const target = this.frameCount + 1;
+				while (this.#running && this.frameCount < target) {
+					this.#runScanline();
+					this.#scanlines++;
+				}
+				await yieldMacrotask();
+				continue;
 			}
 
 			const audio = this.#audio;
@@ -327,6 +356,10 @@ export class Emulator {
 	#collectAudio(pokeyLevel: number, speaker: number): void {
 		const audio = this.#audio;
 		if (!audio?.running) return;
+		// In turbo we generate samples far faster than real-time playback;
+		// queuing them would grow the worklet buffer without bound. Drop them
+		// and let the context underrun to silence until turbo ends.
+		if (this.#turboMode) return;
 
 		const filtered = this.#filter.apply(
 			(pokeyLevel / 60) * 0.2 + speaker * 0.2,

--- a/apps/a8-web/src/host.ts
+++ b/apps/a8-web/src/host.ts
@@ -110,6 +110,9 @@ export class EmulatorHost {
 	/** The measured emulated frame rate, sampled about once a second. */
 	readonly fps = signal(0);
 
+	/** Whether turbo mode (unthrottled, muted) is engaged. */
+	readonly turboMode = signal(false);
+
 	/** Whether the menu sidebar is open. */
 	readonly menuOpen = signal(false);
 
@@ -123,6 +126,7 @@ export class EmulatorHost {
 	#keyInput: HTMLInputElement | null = null;
 	#bootImagePicker: (() => void) | null = null;
 	#cpuTrace = false; // persists across reboots; reapplied to each emulator
+	#turboMode = false; // persists across reboots; reapplied to each emulator
 	// The currently mounted image (kept across reboots; replaced by a Load).
 	#attachment: { cartridge: Cartridge } | { disk: AtrImage } | null = null;
 
@@ -209,6 +213,7 @@ export class EmulatorHost {
 			...(this.#audio && { audio: this.#audio }),
 		});
 		emulator.setTrace(this.#cpuTrace);
+		emulator.setTurboMode(this.#turboMode);
 		return emulator;
 	}
 
@@ -261,6 +266,16 @@ export class EmulatorHost {
 	togglePause(): void {
 		if (this.running.value) this.pause();
 		else this.resume();
+	}
+
+	setTurboMode(enabled: boolean): void {
+		this.#turboMode = enabled;
+		this.#emulator.setTurboMode(enabled);
+		this.turboMode.value = enabled;
+	}
+
+	toggleTurboMode(): void {
+		this.setTurboMode(!this.turboMode.value);
 	}
 
 	setMuted(muted: boolean): void {

--- a/apps/a8-web/src/top-bar.tsx
+++ b/apps/a8-web/src/top-bar.tsx
@@ -16,6 +16,7 @@ export function TopBar({ host }: { host: EmulatorHost }) {
 	const config = host.config.value;
 	const audio = host.audio.value;
 	const running = host.running.value;
+	const turboMode = host.turboMode.value;
 	const fps = host.fps.value;
 	const menuOpen = host.menuOpen.value;
 
@@ -65,6 +66,17 @@ export function TopBar({ host }: { host: EmulatorHost }) {
 					onClick={() => host.dispatch("TOGGLE_PAUSE")}
 				>
 					{running ? "Running" : "Paused"}
+				</button>
+				<button
+					type="button"
+					class={
+						turboMode
+							? "text-amber-400 hover:text-amber-300"
+							: "hover:text-white"
+					}
+					onClick={() => host.dispatch("TURBO_MODE_TOGGLE")}
+				>
+					Turbo mode
 				</button>
 				<span class="w-16 text-right tabular-nums text-neutral-500">
 					{fps ? `${fps} fps` : "—"}


### PR DESCRIPTION
Adds a turbo mode that runs the emulator as fast as the host allows, dropping both the audio buffer gate and the wall-clock sleep so emulation is no longer pinned to real time.

- **Emulator**: `setTurboMode` + a loop branch that runs one emulated frame per macrotask yield (the only thing turbo waits on, so input and the present loop still get a turn) — no sleep, no audio gate. Toggling either way rebases the wall clock and re-anchors the audio queue for a clean handoff.
- **Audio is muted while turbo is on**: real-time playback can't speed up without unbounded buffering, so `#collectAudio` drops samples and the context underruns to silence until turbo ends. (Pitch-preserving fast-forward audio is noted as possible future work.)
- **Host**: `turboMode` signal + `setTurboMode`/`toggleTurboMode`, reapplied to each fresh emulator so it survives reboots.
- **Commands**: `TURBO_MODE_TOGGLE`/`ENABLE`/`DISABLE`.
- **UI**: a clickable "Turbo mode" chip in the top bar, lit amber when engaged. The FPS counter (now reporting the true emulated rate) doubles as a turbo speedometer.

Video self-corrects: the present loop only repaints on a frame change and at most once per RAF, so turbo shows fast-forwarded motion capped at display refresh.