### PR TITLE
feat(a8-web): /docs reference pages and keyboard lab

### DIFF
--- a/apps/a8-web/docs/index.html
+++ b/apps/a8-web/docs/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Atari 8-bit reference</title>
+	</head>
+	<body>
+		<div id="app"></div>
+		<script type="module" src="/src/docs/main.tsx"></script>
+	</body>
+</html>

--- a/apps/a8-web/keyboard-lab.html
+++ b/apps/a8-web/keyboard-lab.html
@@ -1,0 +1,133 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Keyboard event lab</title>
+		<style>
+			:root {
+				color-scheme: dark;
+			}
+			body {
+				margin: 0;
+				font:
+					14px/1.4 ui-monospace,
+					SFMono-Regular,
+					Menlo,
+					monospace;
+				background: #0a0a0a;
+				color: #e5e5e5;
+			}
+			header {
+				padding: 0.75rem 1rem;
+				border-bottom: 1px solid #262626;
+			}
+			h1 {
+				margin: 0 0 0.25rem;
+				font-size: 1rem;
+			}
+			p.hint {
+				margin: 0;
+				color: #a3a3a3;
+				font-size: 0.8rem;
+			}
+			.controls {
+				display: flex;
+				flex-wrap: wrap;
+				gap: 0.75rem;
+				align-items: center;
+				padding: 0.75rem 1rem;
+			}
+			#field {
+				flex: 1 1 16rem;
+				padding: 0.5rem 0.75rem;
+				background: #171717;
+				color: #fff;
+				border: 1px solid #404040;
+				border-radius: 0.375rem;
+				font: inherit;
+			}
+			button,
+			label.toggle {
+				padding: 0.4rem 0.7rem;
+				background: #262626;
+				color: #e5e5e5;
+				border: 1px solid #404040;
+				border-radius: 0.375rem;
+				cursor: pointer;
+				user-select: none;
+			}
+			#mods {
+				padding: 0 1rem 0.5rem;
+				color: #a3a3a3;
+				font-size: 0.8rem;
+				min-height: 1.2em;
+			}
+			#mods .on {
+				color: #fbbf24;
+			}
+			#log {
+				margin: 0;
+				padding: 0.5rem 1rem 2rem;
+				white-space: pre-wrap;
+				word-break: break-word;
+			}
+			.row {
+				padding: 0.1rem 0;
+				border-bottom: 1px solid #1a1a1a;
+			}
+			.t-keydown {
+				color: #4ade80;
+			}
+			.t-keyup {
+				color: #60a5fa;
+			}
+			.t-input,
+			.t-beforeinput {
+				color: #f472b6;
+			}
+			.t-compositionstart,
+			.t-compositionupdate,
+			.t-compositionend {
+				color: #fbbf24;
+			}
+			.dim {
+				color: #737373;
+			}
+		</style>
+	</head>
+	<body>
+		<header>
+			<h1>Keyboard event lab</h1>
+			<p class="hint">
+				Focus the field and type. Every keydown / keyup / beforeinput / input /
+				composition* event is logged here and to the browser console. Try dead
+				keys (e.g. <code>^</code> then <code>a</code>), AltGr, Shift, Ctrl, Caps
+				Lock, and held/repeating keys.
+			</p>
+		</header>
+		<div class="controls">
+			<input
+				id="field"
+				type="text"
+				autocomplete="off"
+				autocapitalize="off"
+				autocorrect="off"
+				spellcheck="false"
+				placeholder="Type here…"
+			/>
+			<label class="toggle">
+				<input id="prevent" type="checkbox" />
+				preventDefault keydown
+			</label>
+			<label class="toggle">
+				<input id="clearField" type="checkbox" checked />
+				auto-clear field
+			</label>
+			<button id="clear" type="button">Clear log</button>
+		</div>
+		<div id="mods"></div>
+		<div id="log"></div>
+		<script type="module" src="/src/keyboard-lab.ts"></script>
+	</body>
+</html>

--- a/apps/a8-web/readme.md
+++ b/apps/a8-web/readme.md
@@ -31,6 +31,11 @@ The headless emulator lives in `@sfotty-pie/a8`; this app is the I/O and chrome 
 - **`audio.ts` / `audio-filter.ts`**, **`palette.ts`**, **`keyboard.ts`** — the host-side I/O building blocks.
 - `window.a8` (from `dev-console.ts`) is a browser-console monitor: peek/poke, a disassembler, CPU/command traces, and the library listing.
 
+### Reference and dev pages
+
+- **`/docs/`** — a generated reference for the keyboard and the ATASCII/ANTIC character set: a keyboard map (hover, or click a key to pin its scan codes and functions), the full character table, the POKEY scan-code table, and the 8×8 key matrix. Built and deployed with the app; source in [`src/docs/`](src/docs/), data in [`src/keyboard-docs.ts`](src/keyboard-docs.ts).
+- **[`keyboard-lab.html`](keyboard-lab.html)** — a dev-only scratch page (served at `/keyboard-lab.html`, not in the production build) that logs raw `keydown` / `keyup` / `input` / `composition` events, handy for untangling browser keyboard quirks.
+
 ## The image library
 
 ROMs and software are loaded from two folders, globbed into one set at build time:
@@ -52,7 +57,7 @@ pnpm --filter @sfotty-pie/a8-web build
 Output is `apps/a8-web/dist/` — plain static files. Notes for hosting:
 
 - **Serve over HTTPS.** Audio (and more later) needs a secure context.
-- It's a single `index.html` with hashed assets and real files under `/legal/`, so **no SPA-style catch-all redirect** is needed.
+- It's static pages (`index.html` and `/docs/`) with hashed assets and real files under `/legal/`, so **no SPA-style catch-all redirect** is needed.
 - The committed build is **firmware-only** — `library.local/` is gitignored, so a clean CI/host build won't include your ROMs or games. Bake those in by populating `library.local/` in your build environment.
 
 Any static host works (e.g. `rsync` the `dist/` to a web root).

--- a/apps/a8-web/src/docs/atascii-table.tsx
+++ b/apps/a8-web/src/docs/atascii-table.tsx
@@ -1,0 +1,238 @@
+import { useState } from "preact/hooks";
+import { FUNCTIONS, KEYS } from "../keyboard-docs.ts";
+import type {
+	AtasciiFunction,
+	FunctionRef,
+	Key as KeyData,
+	PrintableAtascii,
+} from "../keyboard-docs.ts";
+import { Key } from "./key.tsx";
+import { cmpLabel, SortHeader, TABLE, TD, TH } from "./table.tsx";
+
+type CharEntry = PrintableAtascii | AtasciiFunction;
+
+function isControl(f: CharEntry): f is AtasciiFunction {
+	return "glyphName" in f;
+}
+
+// The glyph's name: the Unicode-ish name for printables, the glyph name for
+// control codes (shown the same way).
+function glyphLabel(f: CharEntry): string {
+	return isControl(f) ? f.glyphName : f.name;
+}
+
+// ATASCII -> ANTIC (screen / internal) code, standard character set:
+//   $00-$1F -> $40-$5F, $20-$5F -> $00-$3F, $60-$7F unchanged.
+function toAntic(code: number): number {
+	if (code < 0x20) return code + 0x40;
+	if (code < 0x60) return code - 0x20;
+	return code;
+}
+
+const hex = (n: number) => "$" + n.toString(16).toUpperCase().padStart(2, "0");
+
+const byCode = new Map<number, CharEntry>();
+for (const f of Object.values(FUNCTIONS)) {
+	if ("code" in f) byCode.set(f.code, f);
+}
+
+// Which physical key (and modifier) produces each ATASCII code. Prefer the
+// unmodified key, then Shift, then Control.
+interface Producer {
+	labels: KeyData["labels"];
+	modifier?: "Shift" | "Control";
+}
+const codeToKey = new Map<number, Producer>();
+function codeOf(ref: FunctionRef | undefined): number | undefined {
+	if (ref === undefined) return undefined;
+	const f = FUNCTIONS[ref];
+	return "code" in f ? f.code : undefined;
+}
+for (const [slot, modifier] of [
+	["function", undefined],
+	["withShift", "Shift"],
+	["withControl", "Control"],
+] as const) {
+	for (const k of KEYS) {
+		const code = codeOf(k[slot]);
+		if (code === undefined || code > 0x7f || codeToKey.has(code)) continue;
+		codeToKey.set(code, { labels: k.labels, modifier });
+	}
+}
+
+interface Row {
+	atascii: number;
+	antic: number;
+	entry: CharEntry;
+	inverted?: AtasciiFunction; // the high-bit (inverse-video) function, if any
+}
+
+const ROWS: Row[] = [];
+for (let c = 0; c <= 0x7f; c++) {
+	const entry = byCode.get(c);
+	if (!entry) continue;
+	const high = byCode.get(c | 0x80);
+	ROWS.push({
+		atascii: c,
+		antic: toAntic(c),
+		entry,
+		inverted: high && isControl(high) ? high : undefined,
+	});
+}
+
+type SortKey = "atascii" | "antic" | "key";
+
+const modRank = (m?: "Shift" | "Control") =>
+	m === "Shift" ? 1 : m === "Control" ? 2 : 0;
+
+// The base code, plus its inverse-video counterpart (high bit set) on a second
+// line — rendered in inverse video (filled chip) and muted.
+function Code({
+	value,
+	accent,
+	invChip,
+}: {
+	value: number;
+	accent: string;
+	invChip: string;
+}) {
+	const inv = value | 0x80;
+	return (
+		<span class="inline-flex flex-col items-start gap-1 font-mono whitespace-nowrap">
+			<span>
+				<span class={accent}>{hex(value)}</span>
+				<span class="ml-1.5 text-xs text-neutral-500">{value}</span>
+			</span>
+			<span class={`rounded-xs px-1 text-xs ${invChip}`}>
+				{hex(inv)}
+				<span class="ml-1.5 opacity-70">{inv}</span>
+			</span>
+		</span>
+	);
+}
+
+function Dash() {
+	return <span class="text-neutral-700">—</span>;
+}
+
+function KeyCell({ code }: { code: number }) {
+	const p = codeToKey.get(code);
+	if (!p) return <span class="text-neutral-600 italic">None</span>;
+	return (
+		<span class="inline-flex items-center gap-1.5">
+			{p.modifier && (
+				<span class="rounded bg-neutral-700 px-1.5 py-0.5 text-xs font-semibold text-neutral-100">
+					{p.modifier}
+				</span>
+			)}
+			<Key labels={p.labels} />
+		</span>
+	);
+}
+
+export function AtasciiTable() {
+	const [sortKey, setSortKey] = useState<SortKey>("atascii");
+	const rows = [...ROWS].sort((a, b) => {
+		if (sortKey === "antic") return a.antic - b.antic;
+		if (sortKey === "key") {
+			const pa = codeToKey.get(a.atascii);
+			const pb = codeToKey.get(b.atascii);
+			return (
+				cmpLabel(pa?.labels[0], pb?.labels[0]) ||
+				modRank(pa?.modifier) - modRank(pb?.modifier) ||
+				a.atascii - b.atascii
+			);
+		}
+		return a.atascii - b.atascii;
+	});
+
+	return (
+		<table class={TABLE}>
+			<thead>
+				<tr>
+					<SortHeader
+						label="ATASCII"
+						active={sortKey === "atascii"}
+						onClick={() => setSortKey("atascii")}
+					/>
+					<SortHeader
+						label="ANTIC"
+						active={sortKey === "antic"}
+						onClick={() => setSortKey("antic")}
+					/>
+					<th class={`${TH} text-left`}>Glyph</th>
+					<SortHeader
+						label="Key"
+						active={sortKey === "key"}
+						onClick={() => setSortKey("key")}
+						thClass="text-right"
+					/>
+					<th class={`${TH} text-left`}>Function</th>
+					<th class={`${TH} text-left`}>Inverse function</th>
+					<th class={`${TH} text-left`}>Notes</th>
+				</tr>
+			</thead>
+			<tbody>
+				{rows.map((row) => {
+					const f = row.entry;
+					const ctrl = isControl(f);
+					const alt = !ctrl ? f.altGlyph : undefined;
+					return (
+						<tr key={row.atascii} class="hover:bg-neutral-900/50">
+							<td class={TD}>
+								<Code
+									value={row.atascii}
+									accent="text-amber-300"
+									invChip="bg-amber-300/70 text-neutral-900"
+								/>
+							</td>
+							<td class={TD}>
+								<Code
+									value={row.antic}
+									accent="text-sky-300"
+									invChip="bg-sky-300/70 text-neutral-900"
+								/>
+							</td>
+							<td class={TD}>
+								<div class="text-lg leading-none">{f.glyph}</div>
+								<div class="mt-1 text-xs text-neutral-300">{glyphLabel(f)}</div>
+								{alt && (
+									<div class="mt-0.5 text-xs text-neutral-500">
+										intl: <span class="text-neutral-300">{alt.glyph}</span>{" "}
+										{alt.name}
+									</div>
+								)}
+							</td>
+							<td class={`${TD} text-right`}>
+								<KeyCell code={row.atascii} />
+							</td>
+							<td class={TD}>
+								{ctrl ? (
+									<span class="text-neutral-200">{f.name}</span>
+								) : (
+									<Dash />
+								)}
+							</td>
+							<td class={TD}>
+								{ctrl && row.inverted ? (
+									<span class="text-neutral-200">{row.inverted.name}</span>
+								) : (
+									<Dash />
+								)}
+							</td>
+							<td class={TD}>
+								{f.replacesAscii ? (
+									<span class="text-xs text-neutral-400">
+										replaces ASCII {f.replacesAscii}
+									</span>
+								) : (
+									<Dash />
+								)}
+							</td>
+						</tr>
+					);
+				})}
+			</tbody>
+		</table>
+	);
+}

--- a/apps/a8-web/src/docs/docs.tsx
+++ b/apps/a8-web/src/docs/docs.tsx
@@ -1,0 +1,66 @@
+import { AtasciiTable } from "./atascii-table.tsx";
+import { KeyboardMatrix } from "./keyboard-matrix.tsx";
+import { KeyboardTable } from "./keyboard-table.tsx";
+import { KeyboardView } from "./keyboard-view.tsx";
+
+export function Docs() {
+	return (
+		<div class="min-h-screen bg-neutral-950 text-neutral-200">
+			<header class="border-b border-neutral-800 px-4 py-4">
+				<h1 class="text-xl font-semibold text-neutral-100">
+					Atari 8-bit reference
+				</h1>
+				<p class="mt-1 text-sm text-neutral-500">
+					Character set and keyboard tables, generated from the keyboard
+					reference data.
+				</p>
+			</header>
+			<main class="mx-auto max-w-5xl space-y-12 px-4 py-8">
+				<section>
+					<h2 class="mb-3 text-lg font-semibold text-neutral-100">Keyboard</h2>
+					<KeyboardView />
+				</section>
+				<section>
+					<h2 class="mb-3 text-lg font-semibold text-neutral-100">
+						ATASCII / ANTIC ($00–$7F)
+					</h2>
+					<p class="mb-4 text-sm text-neutral-500">
+						Printable glyphs (with the international character-set alternate),
+						graphics characters, the key that produces each code, and the editor
+						function (plus its inverse-video, $80+, form) for control codes.
+						Click ATASCII, ANTIC, or Key to sort.
+					</p>
+					<div class="overflow-x-auto rounded-lg border border-neutral-800">
+						<AtasciiTable />
+					</div>
+				</section>
+				<section>
+					<h2 class="mb-3 text-lg font-semibold text-neutral-100">
+						Keyboard codes
+					</h2>
+					<p class="mb-4 text-sm text-neutral-500">
+						POKEY scan code for each matrix key, plus the KBCODE for each
+						modifier combination; unmapped codes show as None and the
+						non-scannable Shift+Ctrl codes ($C0–$C7, $D0–$D7) are grayed out.
+						Ordered as digits, letters, punctuation, then other keys; click a
+						header to sort by code or label.
+					</p>
+					<div class="overflow-x-auto rounded-lg border border-neutral-800">
+						<KeyboardTable />
+					</div>
+				</section>
+				<section>
+					<h2 class="mb-3 text-lg font-semibold text-neutral-100">
+						Keyboard matrix
+					</h2>
+					<p class="mb-4 text-sm text-neutral-500">
+						The 64 POKEY scan codes as the 8×8 matrix (row = high 3 bits, column
+						= low 3 bits). Control, Shift, and Break have no scan code of their
+						own — the hardware reads each on the same scan as $00, $10, and $30.
+					</p>
+					<KeyboardMatrix />
+				</section>
+			</main>
+		</div>
+	);
+}

--- a/apps/a8-web/src/docs/key-info.tsx
+++ b/apps/a8-web/src/docs/key-info.tsx
@@ -1,0 +1,180 @@
+import { FUNCTIONS } from "../keyboard-docs.ts";
+import type {
+	AtasciiFunction,
+	FunctionRef,
+	Key as KeyData,
+	KeyFunction,
+	PrintableAtascii,
+} from "../keyboard-docs.ts";
+
+const hex = (n: number) => "$" + n.toString(16).toUpperCase().padStart(2, "0");
+const num = (n: number) => `${hex(n)} (${n})`;
+
+function toAntic(code: number): number {
+	if (code < 0x20) return code + 0x40;
+	if (code < 0x60) return code - 0x20;
+	return code;
+}
+
+function isChar(f: KeyFunction): f is PrintableAtascii | AtasciiFunction {
+	return "code" in f;
+}
+function isControl(
+	f: PrintableAtascii | AtasciiFunction,
+): f is AtasciiFunction {
+	return "glyphName" in f;
+}
+
+// What a single modifier slot produces: a glyph + name with its ATASCII/ANTIC
+// codes (and inverse +$80), or a named/pseudo function. Equivalents and the
+// replaces-ASCII note are intentionally omitted.
+function Produced({ refKey }: { refKey: FunctionRef }) {
+	const f: KeyFunction = FUNCTIONS[refKey];
+	if (isChar(f)) {
+		const base = f.code & 0x7f;
+		const highBit = (f.code & 0x80) !== 0;
+		const name = isControl(f)
+			? `${f.name} (${highBit ? "(INVERTED) " : ""}${f.glyphName})`
+			: f.name;
+		const alt = isControl(f) ? undefined : f.altGlyph;
+		return (
+			<div class="space-y-0.5">
+				<div>
+					<span
+						class={`mr-2 text-lg ${
+							highBit ? "rounded-xs bg-neutral-300 px-1 text-neutral-900" : ""
+						}`}
+					>
+						{f.glyph}
+					</span>
+					<span class="text-neutral-200">{name}</span>
+				</div>
+				{alt && (
+					<div class="text-xs text-neutral-500">
+						intl: <span class="text-neutral-300">{alt.glyph}</span> {alt.name}
+					</div>
+				)}
+				<div class="font-mono text-xs text-neutral-500">
+					ATASCII {num(base)} · +$80 {num(base | 0x80)}
+				</div>
+				<div class="font-mono text-xs text-neutral-500">
+					ANTIC {num(toAntic(base))} · +$80 {num(toAntic(base) | 0x80)}
+				</div>
+			</div>
+		);
+	}
+	return (
+		<div class="space-y-0.5">
+			<div class="text-neutral-200">{f.name}</div>
+			{f.pseudoAtascii !== undefined && (
+				<div class="font-mono text-xs text-neutral-500">
+					pseudo-ATASCII {num(f.pseudoAtascii)}
+				</div>
+			)}
+			{f.handledInKeyboardIrq && (
+				<div class="text-xs text-neutral-500">
+					Handled in the keyboard IRQ — not remappable.
+				</div>
+			)}
+			{f.notes?.map((n) => (
+				<div key={n} class="text-xs text-neutral-500">
+					{n}
+				</div>
+			))}
+		</div>
+	);
+}
+
+const SLOTS = [
+	["function", "Key"],
+	["withShift", "Shift"],
+	["withControl", "Control"],
+] as const;
+
+function Heading({ children }: { children: string }) {
+	return (
+		<div class="mb-1 text-xs font-semibold tracking-wide text-neutral-400 uppercase">
+			{children}
+		</div>
+	);
+}
+
+export function KeyInfo({
+	keyData,
+	pinned = false,
+}: {
+	keyData: KeyData | null;
+	pinned?: boolean;
+}) {
+	if (!keyData) {
+		return (
+			<div class="min-h-36 rounded-lg border border-neutral-800 bg-neutral-900/40 p-4 text-sm text-neutral-500">
+				Hover a key to see its scan codes and what it produces.
+			</div>
+		);
+	}
+
+	const c = keyData.pokeyCode;
+	const noShiftCtrl = keyData.isControlAndShiftScannable === false;
+
+	return (
+		<div class="min-h-36 space-y-3 rounded-lg border border-neutral-800 bg-neutral-900/40 p-4 text-sm">
+			<div class="flex items-center gap-2">
+				<span class="text-base font-semibold text-neutral-100">
+					{keyData.name}
+				</span>
+				{pinned && (
+					<span class="rounded bg-amber-400/20 px-1.5 py-0.5 text-xs font-medium text-amber-300">
+						Pinned — click again to release
+					</span>
+				)}
+			</div>
+
+			{c !== undefined && (
+				<div>
+					<Heading>Scan code</Heading>
+					<div class="flex flex-wrap gap-x-4 gap-y-0.5 font-mono text-xs text-neutral-300">
+						<div>base {num(c)}</div>
+						<div>+Shift {num(c | 0x40)}</div>
+						<div>+Control {num(c | 0x80)}</div>
+						<div class={noShiftCtrl ? "text-neutral-600" : ""}>
+							+Shift+Ctrl {num(c | 0xc0)}
+							{noShiftCtrl && " — not scannable"}
+						</div>
+					</div>
+				</div>
+			)}
+
+			{keyData.notes && keyData.notes.length > 0 && (
+				<div>
+					<Heading>Notes</Heading>
+					<ul class="list-disc space-y-0.5 pl-5 text-xs text-neutral-400">
+						{keyData.notes.map((n) => (
+							<li key={n}>{n}</li>
+						))}
+					</ul>
+				</div>
+			)}
+
+			{(keyData.function || keyData.withShift || keyData.withControl) && (
+				<div>
+					<Heading>Produces</Heading>
+					<div class="space-y-2">
+						{SLOTS.map(([slot, label]) => {
+							const ref = keyData[slot];
+							if (!ref) return null;
+							return (
+								<div key={slot} class="flex gap-3">
+									<div class="w-16 shrink-0 pt-px text-neutral-500">
+										{label}
+									</div>
+									<Produced refKey={ref} />
+								</div>
+							);
+						})}
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/a8-web/src/docs/key.tsx
+++ b/apps/a8-web/src/docs/key.tsx
@@ -1,0 +1,69 @@
+// A rendered Atari keycap. Layout mirrors the physical legend:
+//   - primary label is the main legend (bottom), centred;
+//   - secondary label sits above the primary (centred when alone);
+//   - tertiary label sits to the left of the secondary (pushing it right) and is
+//     drawn in inverse video — the glyph's colour and background swap, the way
+//     the Atari prints its CONTROL graphics symbols.
+// A fixed min-height keeps every cap the same height; the top strip only renders
+// when there's a secondary/tertiary, so single-label caps centre vertically.
+export function Key({
+	labels,
+	fill = false,
+	primary: primaryOverride,
+	inverse = false,
+	small = false,
+	selected = false,
+}: {
+	labels: readonly [primary: string, secondary?: string, tertiary?: string];
+	// `fill` makes the cap take its container's width (for the keyboard view)
+	// instead of its own min-width (for inline use in the tables).
+	fill?: boolean;
+	// View-only overrides: a shortened primary label, an inverse-video primary
+	// label, or a smaller primary font (so long legends fit a narrow cap).
+	primary?: string;
+	inverse?: boolean;
+	small?: boolean;
+	// Pinned indicator for the keyboard view.
+	selected?: boolean;
+}) {
+	const [labelPrimary, secondary, tertiary] = labels;
+	const primary = primaryOverride ?? labelPrimary;
+	const hasTop = secondary !== undefined || tertiary !== undefined;
+
+	const shape = fill ? "flex w-full overflow-hidden" : "inline-flex min-w-12";
+	const ring = selected ? "ring-2 ring-amber-400" : "";
+
+	return (
+		<span
+			class={`${shape} ${ring} min-h-11 flex-col justify-center gap-0.5 rounded-md border border-neutral-600 bg-neutral-800 px-2 py-1 font-mono leading-none`}
+		>
+			{hasTop && (
+				<span
+					class={`flex h-3.5 items-center text-[0.65rem] text-neutral-400 ${
+						tertiary !== undefined ? "justify-start gap-1" : "justify-center"
+					}`}
+				>
+					{tertiary !== undefined && (
+						<span class="rounded-xs bg-neutral-300 px-0.5 text-neutral-900">
+							{tertiary}
+						</span>
+					)}
+					{secondary !== undefined && <span>{secondary}</span>}
+				</span>
+			)}
+			<span
+				class={`flex w-full justify-center leading-none ${
+					small ? "text-[0.6rem]" : "text-sm"
+				}`}
+			>
+				{inverse ? (
+					<span class="rounded-xs bg-neutral-300 px-1 whitespace-nowrap text-neutral-900">
+						{primary}
+					</span>
+				) : (
+					<span class="whitespace-nowrap text-neutral-100">{primary}</span>
+				)}
+			</span>
+		</span>
+	);
+}

--- a/apps/a8-web/src/docs/keyboard-matrix.tsx
+++ b/apps/a8-web/src/docs/keyboard-matrix.tsx
@@ -1,0 +1,73 @@
+import { KEYS } from "../keyboard-docs.ts";
+import type { Key as KeyData } from "../keyboard-docs.ts";
+import { Key } from "./key.tsx";
+
+const hex = (n: number) => "$" + n.toString(16).toUpperCase().padStart(2, "0");
+
+const keyByCode = new Map<number, KeyData>();
+for (const k of KEYS) {
+	if (k.pokeyCode !== undefined) keyByCode.set(k.pokeyCode, k);
+}
+
+// Modifier keys without their own scan code: the hardware reads each on the same
+// scan as the listed code.
+const COSCAN: Record<number, string> = {
+	0x00: "Control",
+	0x10: "Shift",
+	0x30: "Break",
+};
+
+const AXIS = [0, 1, 2, 3, 4, 5, 6, 7];
+
+function Cell({ code }: { code: number }) {
+	const key = keyByCode.get(code);
+	const coscan = COSCAN[code];
+	return (
+		<div class="flex flex-col items-center gap-1 rounded border border-neutral-800 bg-neutral-900/40 p-1.5">
+			<div class="font-mono text-[0.65rem] text-neutral-500">{hex(code)}</div>
+			{key ? (
+				<Key labels={key.labels} />
+			) : (
+				<span class="py-1 text-xs text-neutral-700 italic">None</span>
+			)}
+			{coscan && (
+				<div class="rounded bg-neutral-700 px-1.5 py-0.5 text-[0.65rem] font-semibold text-neutral-100">
+					+{coscan}
+				</div>
+			)}
+		</div>
+	);
+}
+
+export function KeyboardMatrix() {
+	return (
+		<div class="overflow-x-auto">
+			<div
+				class="inline-grid gap-1.5"
+				style={{ gridTemplateColumns: "auto repeat(8, auto)" }}
+			>
+				<div />
+				{AXIS.map((c) => (
+					<div
+						key={`c${c}`}
+						class="text-center font-mono text-xs text-neutral-500"
+					>
+						{c}
+					</div>
+				))}
+				{AXIS.flatMap((r) => [
+					<div
+						key={`r${r}`}
+						class="flex items-center justify-end pr-1 font-mono text-xs text-neutral-500"
+					>
+						{r}
+					</div>,
+					...AXIS.map((c) => {
+						const code = (r << 3) | c;
+						return <Cell key={code} code={code} />;
+					}),
+				])}
+			</div>
+		</div>
+	);
+}

--- a/apps/a8-web/src/docs/keyboard-table.tsx
+++ b/apps/a8-web/src/docs/keyboard-table.tsx
@@ -1,0 +1,100 @@
+import { useState } from "preact/hooks";
+import { KEYS } from "../keyboard-docs.ts";
+import type { Key as KeyData } from "../keyboard-docs.ts";
+import { Key } from "./key.tsx";
+import { cmpLabel, SortHeader, TABLE, TD, TH } from "./table.tsx";
+
+const hex = (n: number) => "$" + n.toString(16).toUpperCase().padStart(2, "0");
+
+interface Row {
+	code: number;
+	key?: KeyData;
+}
+
+const keyByCode = new Map<number, KeyData>();
+for (const k of KEYS) {
+	if (k.pokeyCode !== undefined) keyByCode.set(k.pokeyCode, k);
+}
+
+// POKEY codes are 6-bit; list the whole 0x00-0x3F range so unmapped positions
+// show up too.
+const ROWS: Row[] = [];
+for (let c = 0; c <= 0x3f; c++) ROWS.push({ code: c, key: keyByCode.get(c) });
+
+type SortKey = "code" | "label";
+
+// A KBCODE cell (hex + decimal). `gray` dims a combination the hardware can't
+// scan; `accent` colours the base code.
+function CodeCell({
+	value,
+	accent,
+	gray,
+}: {
+	value: number;
+	accent?: string;
+	gray?: boolean;
+}) {
+	return (
+		<td class={`${TD} font-mono whitespace-nowrap`}>
+			<span class={gray ? "text-neutral-600" : (accent ?? "text-neutral-300")}>
+				{hex(value)}
+			</span>
+			<span
+				class={`ml-1.5 text-xs ${gray ? "text-neutral-700" : "text-neutral-500"}`}
+			>
+				{value}
+			</span>
+		</td>
+	);
+}
+
+export function KeyboardTable() {
+	const [sortKey, setSortKey] = useState<SortKey>("label");
+	const rows = [...ROWS].sort((a, b) =>
+		sortKey === "code"
+			? a.code - b.code
+			: cmpLabel(a.key?.labels[0], b.key?.labels[0]),
+	);
+
+	return (
+		<table class={TABLE}>
+			<thead>
+				<tr>
+					<SortHeader
+						label="POKEY code"
+						active={sortKey === "code"}
+						onClick={() => setSortKey("code")}
+					/>
+					<th class={`${TH} text-left`}>w/Shift</th>
+					<th class={`${TH} text-left`}>w/Control</th>
+					<th class={`${TH} text-left`}>w/Shift+Ctrl</th>
+					<SortHeader
+						label="Key labels"
+						active={sortKey === "label"}
+						onClick={() => setSortKey("label")}
+					/>
+				</tr>
+			</thead>
+			<tbody>
+				{rows.map((row) => (
+					<tr key={row.code} class="hover:bg-neutral-900/50">
+						<CodeCell value={row.code} accent="text-amber-300" />
+						<CodeCell value={row.code | 0x40} />
+						<CodeCell value={row.code | 0x80} />
+						<CodeCell
+							value={row.code | 0xc0}
+							gray={row.key?.isControlAndShiftScannable === false}
+						/>
+						<td class={TD}>
+							{row.key ? (
+								<Key labels={row.key.labels} />
+							) : (
+								<span class="text-neutral-600 italic">None</span>
+							)}
+						</td>
+					</tr>
+				))}
+			</tbody>
+		</table>
+	);
+}

--- a/apps/a8-web/src/docs/keyboard-view.tsx
+++ b/apps/a8-web/src/docs/keyboard-view.tsx
@@ -1,0 +1,206 @@
+import { useState } from "preact/hooks";
+import { KEYS } from "../keyboard-docs.ts";
+import type { Key as KeyData } from "../keyboard-docs.ts";
+import { Key } from "./key.tsx";
+import { KeyInfo } from "./key-info.tsx";
+
+// Layout is in key "units"; PITCH is the rem width of one unit (slot incl. gap).
+// Every main row sums to W units, so the rows line up regardless of key count.
+const PITCH = 3;
+const W = 15.25;
+
+const byRow = new Map<number, KeyData[]>();
+for (const k of KEYS) {
+	const arr = byRow.get(k.row);
+	if (arr) arr.push(k);
+	else byRow.set(k.row, [k]);
+}
+for (const arr of byRow.values()) arr.sort((a, b) => a.column - b.column);
+
+// Widths progress for the left modifiers (ESC < TAB < CONTROL < left SHIFT);
+// RETURN / CAPS / right SHIFT take whatever fills the row out to W.
+function widthOf(k: KeyData): number {
+	switch (k.name) {
+		case "ESC":
+			return 1.25;
+		case "TAB":
+			return 1.5;
+		case "RETURN":
+		case "CONTROL":
+			return 1.75;
+		case "CAPS":
+			return 1.5;
+		case "SHIFT":
+			return k.column === 0 ? 2 : 2.25;
+		default:
+			return 1;
+	}
+}
+
+// View-only per-key tweaks; the data is left unchanged.
+const VIEW: Record<
+	string,
+	{ primary?: string; inverse?: boolean; small?: boolean }
+> = {
+	"BACK SPACE": { primary: "BKSP" },
+	BREAK: { small: true },
+	CONTROL: { inverse: true },
+};
+
+// Row 3 shows the XL/XE order: right SHIFT before the inverse (◩) key.
+function rowKeys(r: number): KeyData[] {
+	const keys = [...(byRow.get(r) ?? [])];
+	if (r === 3 && keys.length >= 2) {
+		const a = keys[keys.length - 2];
+		const b = keys[keys.length - 1];
+		if (a && b) {
+			keys[keys.length - 2] = b;
+			keys[keys.length - 1] = a;
+		}
+	}
+	return keys;
+}
+
+function MainRow({
+	keys,
+	onHover,
+	onSelect,
+	selected,
+}: {
+	keys: KeyData[];
+	onHover: (k: KeyData) => void;
+	onSelect: (k: KeyData) => void;
+	selected: KeyData | null;
+}) {
+	return (
+		<div class="flex">
+			{keys.map((k) => {
+				const o = VIEW[k.name];
+				return (
+					<div
+						key={`${k.row}-${k.column}`}
+						class="p-0.5"
+						style={{ width: `${widthOf(k) * PITCH}rem` }}
+						onMouseEnter={() => onHover(k)}
+						onClick={() => onSelect(k)}
+					>
+						<Key
+							labels={k.labels}
+							fill
+							primary={o?.primary}
+							inverse={o?.inverse}
+							small={o?.small}
+							selected={k === selected}
+						/>
+					</div>
+				);
+			})}
+		</div>
+	);
+}
+
+// Console / function keys: rounded pills, ~1.5 units wide.
+function ConsoleKey({
+	keyData,
+	onHover,
+	onSelect,
+	selected,
+}: {
+	keyData: KeyData;
+	onHover: (k: KeyData) => void;
+	onSelect: (k: KeyData) => void;
+	selected: boolean;
+}) {
+	return (
+		<div
+			class="p-0.5"
+			style={{ width: `${1.5 * PITCH}rem` }}
+			onMouseEnter={() => onHover(keyData)}
+			onClick={() => onSelect(keyData)}
+		>
+			<div
+				class={`flex h-7 items-center justify-center rounded-full border bg-neutral-700 px-1 text-[0.6rem] font-semibold text-neutral-100 ${
+					selected
+						? "border-amber-400 ring-2 ring-amber-400"
+						: "border-neutral-600"
+				}`}
+			>
+				{keyData.name}
+			</div>
+		</div>
+	);
+}
+
+export function KeyboardView() {
+	const [hovered, setHovered] = useState<KeyData | null>(null);
+	const [locked, setLocked] = useState<KeyData | null>(null);
+	const toggle = (k: KeyData) => setLocked((p) => (p === k ? null : k));
+	const shown = locked ?? hovered;
+
+	const space = byRow.get(4)?.[0];
+	const consoleKeys = [...(byRow.get(5) ?? [])].reverse();
+	const fkeys = byRow.get(6) ?? [];
+
+	return (
+		<div class="space-y-4">
+			<div
+				class="cursor-pointer overflow-x-auto select-none"
+				onMouseLeave={() => setHovered(null)}
+			>
+				<div style={{ width: `${W * PITCH}rem` }}>
+					{/* F-keys top-left, console keys top-right (reversed), gap below */}
+					<div class="mb-4 flex justify-between">
+						<div class="flex">
+							{fkeys.map((k) => (
+								<ConsoleKey
+									key={k.name}
+									keyData={k}
+									onHover={setHovered}
+									onSelect={toggle}
+									selected={k === locked}
+								/>
+							))}
+						</div>
+						<div class="flex">
+							{consoleKeys.map((k) => (
+								<ConsoleKey
+									key={k.name}
+									keyData={k}
+									onHover={setHovered}
+									onSelect={toggle}
+									selected={k === locked}
+								/>
+							))}
+						</div>
+					</div>
+					{[0, 1, 2, 3].map((r) => (
+						<MainRow
+							key={r}
+							keys={rowKeys(r)}
+							onHover={setHovered}
+							onSelect={toggle}
+							selected={locked}
+						/>
+					))}
+					{/* Space bar: starts just left of Z, ends near the middle of "/". */}
+					<div class="flex">
+						<div
+							class="p-0.5"
+							style={{
+								marginLeft: `${2.75 * PITCH}rem`,
+								width: `${8.75 * PITCH}rem`,
+							}}
+							onMouseEnter={() => space && setHovered(space)}
+							onClick={() => space && toggle(space)}
+						>
+							{space && (
+								<Key labels={space.labels} fill selected={space === locked} />
+							)}
+						</div>
+					</div>
+				</div>
+			</div>
+			<KeyInfo keyData={shown} pinned={locked !== null} />
+		</div>
+	);
+}

--- a/apps/a8-web/src/docs/main.tsx
+++ b/apps/a8-web/src/docs/main.tsx
@@ -1,0 +1,10 @@
+import { render } from "preact";
+import { Docs } from "./docs.tsx";
+import "../index.css";
+
+function main(): void {
+	const root = document.querySelector<HTMLElement>("#app");
+	if (root) render(<Docs />, root);
+}
+
+main();

--- a/apps/a8-web/src/docs/table.tsx
+++ b/apps/a8-web/src/docs/table.tsx
@@ -1,0 +1,58 @@
+// Shared table chrome for the reference pages.
+
+export const TABLE = "w-full border-collapse text-sm";
+export const TD = "border-b border-neutral-800 px-3 py-1.5 align-top";
+export const TH =
+	"sticky top-0 z-10 border-b border-neutral-700 bg-neutral-900 px-3 py-2 font-semibold text-neutral-300";
+
+export function SortHeader({
+	label,
+	active,
+	onClick,
+	thClass = "text-left",
+}: {
+	label: string;
+	active: boolean;
+	onClick: () => void;
+	thClass?: string;
+}) {
+	return (
+		<th
+			class={`${TH} ${thClass} cursor-pointer select-none hover:text-white`}
+			aria-sort={active ? "ascending" : "none"}
+			onClick={onClick}
+		>
+			{label}
+			<span class="ml-1 text-neutral-600">{active ? "▲" : "↕"}</span>
+		</th>
+	);
+}
+
+// Label ordering shared by both tables: digits, letters, ASCII punctuation (in
+// code order), then other functions (alphabetical); missing labels sort last.
+function isAsciiPunct(c: number): boolean {
+	return (
+		(c >= 0x21 && c <= 0x2f) ||
+		(c >= 0x3a && c <= 0x40) ||
+		(c >= 0x5b && c <= 0x60) ||
+		(c >= 0x7b && c <= 0x7e)
+	);
+}
+
+function labelRank(label: string | undefined): [number, number, string] {
+	if (label === undefined) return [4, 0, ""];
+	if (label.length === 1) {
+		const c = label.charCodeAt(0);
+		if (c >= 0x30 && c <= 0x39) return [0, c, ""]; // digit
+		if ((c >= 0x41 && c <= 0x5a) || (c >= 0x61 && c <= 0x7a))
+			return [1, 0, label.toUpperCase()]; // letter
+		if (isAsciiPunct(c)) return [2, c, ""]; // punctuation, ASCII order
+	}
+	return [3, 0, label]; // other functions, alphabetical
+}
+
+export function cmpLabel(a: string | undefined, b: string | undefined): number {
+	const [ra, na, sa] = labelRank(a);
+	const [rb, nb, sb] = labelRank(b);
+	return ra - rb || na - nb || sa.localeCompare(sb);
+}

--- a/apps/a8-web/src/keyboard-docs.ts
+++ b/apps/a8-web/src/keyboard-docs.ts
@@ -1,0 +1,1753 @@
+// Atari 8-bit keyboard reference: one entry per physical key in KEYS, with
+// the per-key character/function data deduplicated into the FUNCTIONS table.
+// KEYS entries reference FUNCTIONS by key (see FunctionRef).
+
+export interface FunctionDescription {
+	name: string;
+	pseudoAtascii?: number;
+	asciiEquivalent?: string;
+	ansiEquivalent?: string;
+	ctrlKeyEquivalent?: string;
+	pcKeyEquivalent?: string;
+	// Serviced directly in the keyboard IRQ before KEYDEF translation, so it
+	// can't be remapped.
+	handledInKeyboardIrq?: boolean;
+	notes?: string[];
+}
+
+export interface PrintableAtascii {
+	code: number;
+	glyph: string;
+	name: string;
+	replacesAscii?: string;
+	altGlyph?: {
+		glyph: string;
+		name: string;
+	};
+}
+
+export interface AtasciiFunction extends FunctionDescription {
+	code: number;
+	glyph: string;
+	glyphName: string;
+	replacesAscii?: string;
+}
+
+// A key press yields a printable ATASCII glyph (PrintableAtascii), a control
+// code with a named function (AtasciiFunction), or a pseudo-ATASCII / IRQ
+// function with no character at all (plain FunctionDescription).
+export type KeyFunction =
+	| PrintableAtascii
+	| AtasciiFunction
+	| FunctionDescription;
+
+// Each entry is keyed by its glyph if it's a plain ASCII printable character, by
+// its ATASCII hex code ("0x1b") if it's an Atari graphics / control / pseudo
+// code, or by a short name ("RESET") if it has no ATASCII representation at all.
+export const FUNCTIONS = {
+	"0x00": {
+		code: 0x00, // 0
+		glyph: "♥",
+		name: "BLACK HEART SUIT",
+		replacesAscii: "NUL (Null)",
+		altGlyph: {
+			glyph: "á",
+			name: "LATIN SMALL LETTER A WITH ACUTE",
+		},
+	},
+	"0x01": {
+		code: 0x01, // 1
+		glyph: "├",
+		name: "BOX DRAWINGS LIGHT VERTICAL AND RIGHT",
+		replacesAscii: "SOH (Start of Heading)",
+		altGlyph: {
+			glyph: "ù",
+			name: "LATIN SMALL LETTER U WITH GRAVE",
+		},
+	},
+	"0x02": {
+		code: 0x02, // 2
+		glyph: "▕",
+		name: "RIGHT ONE EIGHTH BLOCK",
+		replacesAscii: "STX (Start of Text)",
+		altGlyph: {
+			glyph: "Ñ",
+			name: "LATIN CAPITAL LETTER N WITH TILDE",
+		},
+	},
+	"0x03": {
+		code: 0x03, // 3
+		glyph: "┘",
+		name: "BOX DRAWINGS LIGHT UP AND LEFT",
+		replacesAscii: "ETX (End of Text)",
+		altGlyph: {
+			glyph: "É",
+			name: "LATIN CAPITAL LETTER E WITH ACUTE",
+		},
+	},
+	"0x04": {
+		code: 0x04, // 4
+		glyph: "┤",
+		name: "BOX DRAWINGS LIGHT VERTICAL AND LEFT",
+		replacesAscii: "EOT (End of Transmission)",
+		altGlyph: {
+			glyph: "ç",
+			name: "LATIN SMALL LETTER C WITH CEDILLA",
+		},
+	},
+	"0x05": {
+		code: 0x05, // 5
+		glyph: "┐",
+		name: "BOX DRAWINGS LIGHT DOWN AND LEFT",
+		replacesAscii: "ENQ (Enquiry)",
+		altGlyph: {
+			glyph: "ô",
+			name: "LATIN SMALL LETTER O WITH CIRCUMFLEX",
+		},
+	},
+	"0x06": {
+		code: 0x06, // 6
+		glyph: "╱",
+		name: "BOX DRAWINGS LIGHT DIAGONAL UPPER RIGHT TO LOWER LEFT",
+		replacesAscii: "ACK (Acknowledgement)",
+		altGlyph: {
+			glyph: "ò",
+			name: "LATIN SMALL LETTER O WITH GRAVE",
+		},
+	},
+	"0x07": {
+		code: 0x07, // 7
+		glyph: "╲",
+		name: "BOX DRAWINGS LIGHT DIAGONAL UPPER LEFT TO LOWER RIGHT",
+		replacesAscii: "BEL (Bell)",
+		altGlyph: {
+			glyph: "ì",
+			name: "LATIN SMALL LETTER I WITH GRAVE",
+		},
+	},
+	"0x08": {
+		code: 0x08, // 8
+		glyph: "◢",
+		name: "BLACK LOWER RIGHT TRIANGLE",
+		replacesAscii: "BS (Backspace)",
+		altGlyph: {
+			glyph: "£",
+			name: "POUND SIGN",
+		},
+	},
+	"0x09": {
+		code: 0x09, // 9
+		glyph: "▗",
+		name: "QUADRANT LOWER RIGHT",
+		replacesAscii: "HT (Horizontal Tab)",
+		altGlyph: {
+			glyph: "ï",
+			name: "LATIN SMALL LETTER I WITH DIAERESIS",
+		},
+	},
+	"0x0a": {
+		code: 0x0a, // 10
+		glyph: "◣",
+		name: "BLACK LOWER LEFT TRIANGLE",
+		replacesAscii: "LF (Line Feed)",
+		altGlyph: {
+			glyph: "ü",
+			name: "LATIN SMALL LETTER U WITH DIAERESIS",
+		},
+	},
+	"0x0b": {
+		code: 0x0b, // 11
+		glyph: "▝",
+		name: "QUADRANT UPPER RIGHT",
+		replacesAscii: "VT (Vertical Tab)",
+		altGlyph: {
+			glyph: "ä",
+			name: "LATIN SMALL LETTER A WITH DIAERESIS",
+		},
+	},
+	"0x0c": {
+		code: 0x0c, // 12
+		glyph: "▘",
+		name: "QUADRANT UPPER LEFT",
+		replacesAscii: "FF (Form Feed)",
+		altGlyph: {
+			glyph: "Ö",
+			name: "LATIN CAPITAL LETTER O WITH DIAERESIS",
+		},
+	},
+	"0x0d": {
+		code: 0x0d, // 13
+		glyph: "▔",
+		name: "UPPER ONE EIGHTH BLOCK",
+		replacesAscii: "CR (Carriage Return)",
+		altGlyph: {
+			glyph: "ú",
+			name: "LATIN SMALL LETTER U WITH ACUTE",
+		},
+	},
+	"0x0e": {
+		code: 0x0e, // 14
+		glyph: "▂",
+		name: "LOWER ONE QUARTER BLOCK",
+		replacesAscii: "SO (Shift Out)",
+		altGlyph: {
+			glyph: "ó",
+			name: "LATIN SMALL LETTER O WITH ACUTE",
+		},
+	},
+	"0x0f": {
+		code: 0x0f, // 15
+		glyph: "▖",
+		name: "QUADRANT LOWER LEFT",
+		replacesAscii: "SI (Shift In)",
+		altGlyph: {
+			glyph: "ö",
+			name: "LATIN SMALL LETTER O WITH DIAERESIS",
+		},
+	},
+	"0x10": {
+		code: 0x10, // 16
+		glyph: "♣",
+		name: "BLACK CLUB SUIT",
+		replacesAscii: "DLE (Data Link Escape)",
+		altGlyph: {
+			glyph: "Ü",
+			name: "LATIN CAPITAL LETTER U WITH DIAERESIS",
+		},
+	},
+	"0x11": {
+		code: 0x11, // 17
+		glyph: "┌",
+		name: "BOX DRAWINGS LIGHT DOWN AND RIGHT",
+		replacesAscii: "DC1 (Device Control 1)",
+		altGlyph: {
+			glyph: "â",
+			name: "LATIN SMALL LETTER A WITH CIRCUMFLEX",
+		},
+	},
+	"0x12": {
+		code: 0x12, // 18
+		glyph: "─",
+		name: "BOX DRAWINGS LIGHT HORIZONTAL",
+		replacesAscii: "DC2 (Device Control 2)",
+		altGlyph: {
+			glyph: "û",
+			name: "LATIN SMALL LETTER U WITH CIRCUMFLEX",
+		},
+	},
+	"0x13": {
+		code: 0x13, // 19
+		glyph: "┼",
+		name: "BOX DRAWINGS LIGHT VERTICAL AND HORIZONTAL",
+		replacesAscii: "DC3 (Device Control 3)",
+		altGlyph: {
+			glyph: "î",
+			name: "LATIN SMALL LETTER I WITH CIRCUMFLEX",
+		},
+	},
+	"0x14": {
+		code: 0x14, // 20
+		glyph: "•",
+		name: "BULLET",
+		replacesAscii: "DC4 (Device Control 4)",
+		altGlyph: {
+			glyph: "é",
+			name: "LATIN SMALL LETTER E WITH ACUTE",
+		},
+	},
+	"0x15": {
+		code: 0x15, // 21
+		glyph: "▄",
+		name: "LOWER HALF BLOCK",
+		replacesAscii: "NAK (Negative Acknowledgement)",
+		altGlyph: {
+			glyph: "è",
+			name: "LATIN SMALL LETTER E WITH GRAVE",
+		},
+	},
+	"0x16": {
+		code: 0x16, // 22
+		glyph: "▎",
+		name: "LEFT ONE QUARTER BLOCK",
+		replacesAscii: "SYN (Synchronous Idle)",
+		altGlyph: {
+			glyph: "ñ",
+			name: "LATIN SMALL LETTER N WITH TILDE",
+		},
+	},
+	"0x17": {
+		code: 0x17, // 23
+		glyph: "┬",
+		name: "BOX DRAWINGS LIGHT DOWN AND HORIZONTAL",
+		replacesAscii: "ETB (End of Transmission Block)",
+		altGlyph: {
+			glyph: "ê",
+			name: "LATIN SMALL LETTER E WITH CIRCUMFLEX",
+		},
+	},
+	"0x18": {
+		code: 0x18, // 24
+		glyph: "┴",
+		name: "BOX DRAWINGS LIGHT UP AND HORIZONTAL",
+		replacesAscii: "CAN (Cancel)",
+		altGlyph: {
+			glyph: "å",
+			name: "LATIN SMALL LETTER A WITH RING ABOVE",
+		},
+	},
+	"0x19": {
+		code: 0x19, // 25
+		glyph: "▌",
+		name: "LEFT HALF BLOCK",
+		replacesAscii: "EM (End of Medium)",
+		altGlyph: {
+			glyph: "à",
+			name: "LATIN SMALL LETTER A WITH GRAVE",
+		},
+	},
+	"0x1a": {
+		code: 0x1a, // 26
+		glyph: "└",
+		name: "BOX DRAWINGS LIGHT UP AND RIGHT",
+		replacesAscii: "SUB (Substitute)",
+		altGlyph: {
+			glyph: "Å",
+			name: "LATIN CAPITAL LETTER A WITH RING ABOVE",
+		},
+	},
+	"0x1b": {
+		code: 0x1b, // 27
+		glyph: "␛",
+		glyphName: "SYMBOL FOR ESCAPE",
+		name: "Escape",
+		asciiEquivalent: "\x1b",
+		pcKeyEquivalent: "Esc",
+	},
+	"0x1c": {
+		code: 0x1c, // 28
+		glyph: "↑",
+		glyphName: "UPWARDS ARROW",
+		replacesAscii: "FS (File Separator)",
+		name: "Cursor up",
+		ansiEquivalent: "\x1b[A",
+		ctrlKeyEquivalent: "Ctrl+P",
+		pcKeyEquivalent: "↑",
+	},
+	"0x1d": {
+		code: 0x1d, // 29
+		glyph: "↓",
+		glyphName: "DOWNWARDS ARROW",
+		replacesAscii: "GS (Group Separator)",
+		name: "Cursor down",
+		ansiEquivalent: "\x1b[B",
+		ctrlKeyEquivalent: "Ctrl+N",
+		pcKeyEquivalent: "↓",
+	},
+	"0x1e": {
+		code: 0x1e, // 30
+		glyph: "←",
+		glyphName: "LEFTWARDS ARROW",
+		replacesAscii: "RS (Record Separator)",
+		name: "Cursor left",
+		ansiEquivalent: "\x1b[D",
+		ctrlKeyEquivalent: "Ctrl+B",
+		pcKeyEquivalent: "←",
+	},
+	"0x1f": {
+		code: 0x1f, // 31
+		glyph: "→",
+		glyphName: "RIGHTWARDS ARROW",
+		replacesAscii: "US (Unit Separator)",
+		name: "Cursor right",
+		ansiEquivalent: "\x1b[C",
+		ctrlKeyEquivalent: "Ctrl+F",
+		pcKeyEquivalent: "→",
+	},
+	" ": {
+		code: 0x20, // 32
+		glyph: " ",
+		name: "SPACE",
+	},
+	"!": {
+		code: 0x21, // 33
+		glyph: "!",
+		name: "EXCLAMATION MARK",
+	},
+	'"': {
+		code: 0x22, // 34
+		glyph: '"',
+		name: "QUOTATION MARK",
+	},
+	"#": {
+		code: 0x23, // 35
+		glyph: "#",
+		name: "NUMBER SIGN",
+	},
+	$: {
+		code: 0x24, // 36
+		glyph: "$",
+		name: "DOLLAR SIGN",
+	},
+	"%": {
+		code: 0x25, // 37
+		glyph: "%",
+		name: "PERCENT SIGN",
+	},
+	"&": {
+		code: 0x26, // 38
+		glyph: "&",
+		name: "AMPERSAND",
+	},
+	"'": {
+		code: 0x27, // 39
+		glyph: "'",
+		name: "APOSTROPHE",
+	},
+	"(": {
+		code: 0x28, // 40
+		glyph: "(",
+		name: "LEFT PARENTHESIS",
+	},
+	")": {
+		code: 0x29, // 41
+		glyph: ")",
+		name: "RIGHT PARENTHESIS",
+	},
+	"*": {
+		code: 0x2a, // 42
+		glyph: "*",
+		name: "ASTERISK",
+	},
+	"+": {
+		code: 0x2b, // 43
+		glyph: "+",
+		name: "PLUS SIGN",
+	},
+	",": {
+		code: 0x2c, // 44
+		glyph: ",",
+		name: "COMMA",
+	},
+	"-": {
+		code: 0x2d, // 45
+		glyph: "-",
+		name: "HYPHEN-MINUS",
+	},
+	".": {
+		code: 0x2e, // 46
+		glyph: ".",
+		name: "FULL STOP",
+	},
+	"/": {
+		code: 0x2f, // 47
+		glyph: "/",
+		name: "SOLIDUS",
+	},
+	"0": {
+		code: 0x30, // 48
+		glyph: "0",
+		name: "DIGIT ZERO",
+	},
+	"1": {
+		code: 0x31, // 49
+		glyph: "1",
+		name: "DIGIT ONE",
+	},
+	"2": {
+		code: 0x32, // 50
+		glyph: "2",
+		name: "DIGIT TWO",
+	},
+	"3": {
+		code: 0x33, // 51
+		glyph: "3",
+		name: "DIGIT THREE",
+	},
+	"4": {
+		code: 0x34, // 52
+		glyph: "4",
+		name: "DIGIT FOUR",
+	},
+	"5": {
+		code: 0x35, // 53
+		glyph: "5",
+		name: "DIGIT FIVE",
+	},
+	"6": {
+		code: 0x36, // 54
+		glyph: "6",
+		name: "DIGIT SIX",
+	},
+	"7": {
+		code: 0x37, // 55
+		glyph: "7",
+		name: "DIGIT SEVEN",
+	},
+	"8": {
+		code: 0x38, // 56
+		glyph: "8",
+		name: "DIGIT EIGHT",
+	},
+	"9": {
+		code: 0x39, // 57
+		glyph: "9",
+		name: "DIGIT NINE",
+	},
+	":": {
+		code: 0x3a, // 58
+		glyph: ":",
+		name: "COLON",
+	},
+	";": {
+		code: 0x3b, // 59
+		glyph: ";",
+		name: "SEMICOLON",
+	},
+	"<": {
+		code: 0x3c, // 60
+		glyph: "<",
+		name: "LESS-THAN SIGN",
+	},
+	"=": {
+		code: 0x3d, // 61
+		glyph: "=",
+		name: "EQUALS SIGN",
+	},
+	">": {
+		code: 0x3e, // 62
+		glyph: ">",
+		name: "GREATER-THAN SIGN",
+	},
+	"?": {
+		code: 0x3f, // 63
+		glyph: "?",
+		name: "QUESTION MARK",
+	},
+	"@": {
+		code: 0x40, // 64
+		glyph: "@",
+		name: "COMMERCIAL AT",
+	},
+	A: {
+		code: 0x41, // 65
+		glyph: "A",
+		name: "LATIN CAPITAL LETTER A",
+	},
+	B: {
+		code: 0x42, // 66
+		glyph: "B",
+		name: "LATIN CAPITAL LETTER B",
+	},
+	C: {
+		code: 0x43, // 67
+		glyph: "C",
+		name: "LATIN CAPITAL LETTER C",
+	},
+	D: {
+		code: 0x44, // 68
+		glyph: "D",
+		name: "LATIN CAPITAL LETTER D",
+	},
+	E: {
+		code: 0x45, // 69
+		glyph: "E",
+		name: "LATIN CAPITAL LETTER E",
+	},
+	F: {
+		code: 0x46, // 70
+		glyph: "F",
+		name: "LATIN CAPITAL LETTER F",
+	},
+	G: {
+		code: 0x47, // 71
+		glyph: "G",
+		name: "LATIN CAPITAL LETTER G",
+	},
+	H: {
+		code: 0x48, // 72
+		glyph: "H",
+		name: "LATIN CAPITAL LETTER H",
+	},
+	I: {
+		code: 0x49, // 73
+		glyph: "I",
+		name: "LATIN CAPITAL LETTER I",
+	},
+	J: {
+		code: 0x4a, // 74
+		glyph: "J",
+		name: "LATIN CAPITAL LETTER J",
+	},
+	K: {
+		code: 0x4b, // 75
+		glyph: "K",
+		name: "LATIN CAPITAL LETTER K",
+	},
+	L: {
+		code: 0x4c, // 76
+		glyph: "L",
+		name: "LATIN CAPITAL LETTER L",
+	},
+	M: {
+		code: 0x4d, // 77
+		glyph: "M",
+		name: "LATIN CAPITAL LETTER M",
+	},
+	N: {
+		code: 0x4e, // 78
+		glyph: "N",
+		name: "LATIN CAPITAL LETTER N",
+	},
+	O: {
+		code: 0x4f, // 79
+		glyph: "O",
+		name: "LATIN CAPITAL LETTER O",
+	},
+	P: {
+		code: 0x50, // 80
+		glyph: "P",
+		name: "LATIN CAPITAL LETTER P",
+	},
+	Q: {
+		code: 0x51, // 81
+		glyph: "Q",
+		name: "LATIN CAPITAL LETTER Q",
+	},
+	R: {
+		code: 0x52, // 82
+		glyph: "R",
+		name: "LATIN CAPITAL LETTER R",
+	},
+	S: {
+		code: 0x53, // 83
+		glyph: "S",
+		name: "LATIN CAPITAL LETTER S",
+	},
+	T: {
+		code: 0x54, // 84
+		glyph: "T",
+		name: "LATIN CAPITAL LETTER T",
+	},
+	U: {
+		code: 0x55, // 85
+		glyph: "U",
+		name: "LATIN CAPITAL LETTER U",
+	},
+	V: {
+		code: 0x56, // 86
+		glyph: "V",
+		name: "LATIN CAPITAL LETTER V",
+	},
+	W: {
+		code: 0x57, // 87
+		glyph: "W",
+		name: "LATIN CAPITAL LETTER W",
+	},
+	X: {
+		code: 0x58, // 88
+		glyph: "X",
+		name: "LATIN CAPITAL LETTER X",
+	},
+	Y: {
+		code: 0x59, // 89
+		glyph: "Y",
+		name: "LATIN CAPITAL LETTER Y",
+	},
+	Z: {
+		code: 0x5a, // 90
+		glyph: "Z",
+		name: "LATIN CAPITAL LETTER Z",
+	},
+	"[": {
+		code: 0x5b, // 91
+		glyph: "[",
+		name: "LEFT SQUARE BRACKET",
+	},
+	"\\": {
+		code: 0x5c, // 92
+		glyph: "\\",
+		name: "REVERSE SOLIDUS",
+	},
+	"]": {
+		code: 0x5d, // 93
+		glyph: "]",
+		name: "RIGHT SQUARE BRACKET",
+	},
+	"^": {
+		code: 0x5e, // 94
+		glyph: "^",
+		name: "CIRCUMFLEX ACCENT",
+	},
+	_: {
+		code: 0x5f, // 95
+		glyph: "_",
+		name: "LOW LINE",
+	},
+	"0x60": {
+		code: 0x60, // 96
+		glyph: "♦",
+		name: "BLACK DIAMOND SUIT",
+		replacesAscii: "GRAVE ACCENT (`)",
+		altGlyph: {
+			glyph: "¡",
+			name: "INVERTED EXCLAMATION MARK",
+		},
+	},
+	a: {
+		code: 0x61, // 97
+		glyph: "a",
+		name: "LATIN SMALL LETTER A",
+	},
+	b: {
+		code: 0x62, // 98
+		glyph: "b",
+		name: "LATIN SMALL LETTER B",
+	},
+	c: {
+		code: 0x63, // 99
+		glyph: "c",
+		name: "LATIN SMALL LETTER C",
+	},
+	d: {
+		code: 0x64, // 100
+		glyph: "d",
+		name: "LATIN SMALL LETTER D",
+	},
+	e: {
+		code: 0x65, // 101
+		glyph: "e",
+		name: "LATIN SMALL LETTER E",
+	},
+	f: {
+		code: 0x66, // 102
+		glyph: "f",
+		name: "LATIN SMALL LETTER F",
+	},
+	g: {
+		code: 0x67, // 103
+		glyph: "g",
+		name: "LATIN SMALL LETTER G",
+	},
+	h: {
+		code: 0x68, // 104
+		glyph: "h",
+		name: "LATIN SMALL LETTER H",
+	},
+	i: {
+		code: 0x69, // 105
+		glyph: "i",
+		name: "LATIN SMALL LETTER I",
+	},
+	j: {
+		code: 0x6a, // 106
+		glyph: "j",
+		name: "LATIN SMALL LETTER J",
+	},
+	k: {
+		code: 0x6b, // 107
+		glyph: "k",
+		name: "LATIN SMALL LETTER K",
+	},
+	l: {
+		code: 0x6c, // 108
+		glyph: "l",
+		name: "LATIN SMALL LETTER L",
+	},
+	m: {
+		code: 0x6d, // 109
+		glyph: "m",
+		name: "LATIN SMALL LETTER M",
+	},
+	n: {
+		code: 0x6e, // 110
+		glyph: "n",
+		name: "LATIN SMALL LETTER N",
+	},
+	o: {
+		code: 0x6f, // 111
+		glyph: "o",
+		name: "LATIN SMALL LETTER O",
+	},
+	p: {
+		code: 0x70, // 112
+		glyph: "p",
+		name: "LATIN SMALL LETTER P",
+	},
+	q: {
+		code: 0x71, // 113
+		glyph: "q",
+		name: "LATIN SMALL LETTER Q",
+	},
+	r: {
+		code: 0x72, // 114
+		glyph: "r",
+		name: "LATIN SMALL LETTER R",
+	},
+	s: {
+		code: 0x73, // 115
+		glyph: "s",
+		name: "LATIN SMALL LETTER S",
+	},
+	t: {
+		code: 0x74, // 116
+		glyph: "t",
+		name: "LATIN SMALL LETTER T",
+	},
+	u: {
+		code: 0x75, // 117
+		glyph: "u",
+		name: "LATIN SMALL LETTER U",
+	},
+	v: {
+		code: 0x76, // 118
+		glyph: "v",
+		name: "LATIN SMALL LETTER V",
+	},
+	w: {
+		code: 0x77, // 119
+		glyph: "w",
+		name: "LATIN SMALL LETTER W",
+	},
+	x: {
+		code: 0x78, // 120
+		glyph: "x",
+		name: "LATIN SMALL LETTER X",
+	},
+	y: {
+		code: 0x79, // 121
+		glyph: "y",
+		name: "LATIN SMALL LETTER Y",
+	},
+	z: {
+		code: 0x7a, // 122
+		glyph: "z",
+		name: "LATIN SMALL LETTER Z",
+	},
+	"0x7b": {
+		code: 0x7b, // 123
+		glyph: "♠",
+		name: "BLACK SPADE SUIT",
+		replacesAscii: "LEFT CURLY BRACKET ({)",
+		altGlyph: {
+			glyph: "Ä",
+			name: "LATIN CAPITAL LETTER A WITH DIAERESIS",
+		},
+	},
+	"|": {
+		code: 0x7c, // 124
+		glyph: "|",
+		name: "VERTICAL LINE",
+	},
+	"0x7d": {
+		code: 0x7d, // 125
+		glyph: "↖",
+		glyphName: "NORTH WEST ARROW",
+		replacesAscii: "RIGHT CURLY BRACKET (})",
+		name: "Clear screen",
+		asciiEquivalent: "\f",
+		ansiEquivalent: "\x1b[2J\x1b[H",
+		ctrlKeyEquivalent: "Ctrl+L",
+	},
+	"0x7e": {
+		code: 0x7e, // 126
+		glyph: "◀",
+		glyphName: "BLACK LEFT-POINTING TRIANGLE",
+		replacesAscii: "TILDE (~)",
+		name: "Backspace",
+		asciiEquivalent: "\b",
+		ansiEquivalent: "\b \b",
+		ctrlKeyEquivalent: "Ctrl+H",
+		pcKeyEquivalent: "Backspace",
+	},
+	"0x7f": {
+		code: 0x7f, // 127
+		glyph: "▶",
+		glyphName: "BLACK RIGHT-POINTING TRIANGLE",
+		replacesAscii: "DELETE (DEL)",
+		name: "Tab",
+		asciiEquivalent: "\t",
+		ansiEquivalent: "\t",
+		ctrlKeyEquivalent: "Ctrl+I",
+		pcKeyEquivalent: "Tab",
+	},
+	"0x81": {
+		name: "Toggle inverse video",
+		pseudoAtascii: 0x81, // 129
+	},
+	"0x82": {
+		name: "Toggle lowercase mode",
+		pseudoAtascii: 0x82, // 130
+		pcKeyEquivalent: "Caps Lock",
+		notes: [
+			"Differs by OS: the 400/800 OS always switches to lowercase mode, whereas the XL/XE OS toggles between lowercase and uppercase.",
+		],
+	},
+	"0x83": {
+		name: "Switch to uppercase mode",
+		pseudoAtascii: 0x83, // 131
+	},
+	"0x84": {
+		name: "Switch to graphics mode",
+		pseudoAtascii: 0x84, // 132
+	},
+	"0x85": {
+		name: "Generate end-of-file condition",
+		pseudoAtascii: 0x85, // 133
+		asciiEquivalent: "\x04",
+		ctrlKeyEquivalent: "Ctrl+D",
+	},
+	"0x89": {
+		name: "Toggle key click enable/disable",
+		pseudoAtascii: 0x89, // 137
+	},
+	"0x8e": {
+		name: "Cursor to upper left corner",
+		pseudoAtascii: 0x8e, // 142
+		ansiEquivalent: "\x1b[H",
+		pcKeyEquivalent: "Ctrl+Home",
+	},
+	"0x8f": {
+		name: "Cursor to lower left corner",
+		pseudoAtascii: 0x8f, // 143
+	},
+	"0x90": {
+		name: "Cursor to beginning of physical line",
+		pseudoAtascii: 0x90, // 144
+		asciiEquivalent: "\r",
+		ansiEquivalent: "\x1b[G",
+		ctrlKeyEquivalent: "Ctrl+A",
+		pcKeyEquivalent: "Home",
+	},
+	"0x91": {
+		name: "Cursor to end of physical line",
+		pseudoAtascii: 0x91, // 145
+		ctrlKeyEquivalent: "Ctrl+E",
+		pcKeyEquivalent: "End",
+	},
+	"0x9b": {
+		code: 0x9b, // 155
+		glyph: "␛",
+		glyphName: "SYMBOL FOR ESCAPE",
+		name: "End of line",
+		asciiEquivalent: "\n",
+		ansiEquivalent: "\r\n",
+		ctrlKeyEquivalent: "Ctrl+M",
+		pcKeyEquivalent: "Enter",
+	},
+	"0x9c": {
+		code: 0x9c, // 156
+		glyph: "↑",
+		glyphName: "UPWARDS ARROW",
+		replacesAscii: "FS (File Separator)",
+		name: "Delete line",
+		ansiEquivalent: "\x1b[M",
+	},
+	"0x9d": {
+		code: 0x9d, // 157
+		glyph: "↓",
+		glyphName: "DOWNWARDS ARROW",
+		replacesAscii: "GS (Group Separator)",
+		name: "Insert line",
+		ansiEquivalent: "\x1b[L",
+	},
+	"0x9e": {
+		code: 0x9e, // 158
+		glyph: "←",
+		glyphName: "LEFTWARDS ARROW",
+		replacesAscii: "RS (Record Separator)",
+		name: "Clear tab stop",
+		ansiEquivalent: "\x1b[0g",
+	},
+	"0x9f": {
+		code: 0x9f, // 159
+		glyph: "→",
+		glyphName: "RIGHTWARDS ARROW",
+		replacesAscii: "US (Unit Separator)",
+		name: "Set tab stop",
+		ansiEquivalent: "\x1bH",
+	},
+	"0xfd": {
+		code: 0xfd, // 253
+		glyph: "↖",
+		glyphName: "NORTH WEST ARROW",
+		replacesAscii: "RIGHT CURLY BRACKET (})",
+		name: "Bell",
+		asciiEquivalent: "\x07",
+		ansiEquivalent: "\x07",
+		ctrlKeyEquivalent: "Ctrl+G",
+	},
+	"0xfe": {
+		code: 0xfe, // 254
+		glyph: "◀",
+		glyphName: "BLACK LEFT-POINTING TRIANGLE",
+		replacesAscii: "TILDE (~)",
+		name: "Delete character",
+		asciiEquivalent: "\x7f",
+		ansiEquivalent: "\x1b[P",
+		ctrlKeyEquivalent: "Ctrl+D",
+		pcKeyEquivalent: "Delete",
+	},
+	"0xff": {
+		code: 0xff, // 255
+		glyph: "▶",
+		glyphName: "BLACK RIGHT-POINTING TRIANGLE",
+		replacesAscii: "DELETE (DEL)",
+		name: "Insert character",
+		ansiEquivalent: "\x1b[@",
+	},
+	BREAK: {
+		name: "Break",
+		ctrlKeyEquivalent: "Ctrl+C",
+		pcKeyEquivalent: "Ctrl+Break",
+	},
+	CHARSET: {
+		name: "Toggle domestic/international character set",
+		handledInKeyboardIrq: true,
+		notes: [
+			"On the 1988 revision of the Arabic 65XE OS, also toggled by SHIFT+HELP.",
+			"Status reflected on LED L2 on the 1200XL.",
+		],
+	},
+	CONTROL: {
+		name: "Control",
+		pcKeyEquivalent: "Ctrl",
+		notes: ["Modifier: selects each key's control character or function."],
+	},
+	HELP: {
+		name: "Help",
+		pcKeyEquivalent: "F1",
+		notes: [
+			"Sets the HELPFG flag ($02DC) for applications to read; has no screen-editor function.",
+		],
+	},
+	KBD_ENABLE: {
+		name: "Toggle keyboard enable/disable",
+		handledInKeyboardIrq: true,
+		notes: ["Status reflected on LED L1 on the 1200XL."],
+	},
+	OPTION: {
+		name: "Option",
+		notes: [
+			"Read directly from the CONSOL register ($D01F); no fixed OS function.",
+			"Held at power-on, disables the built-in BASIC (XL/XE); on the XEGS it also disables the built-in Missile Command.",
+		],
+	},
+	PAUSE: {
+		name: "Toggle screen output pause/resume",
+		pcKeyEquivalent: "Pause",
+		handledInKeyboardIrq: true,
+	},
+	RESET: {
+		name: "Reset",
+		notes: [
+			"On 400/800, it generates a RESET NMI via ANTIC.",
+			"On XL/XE, it generates a real CPU reset.",
+		],
+	},
+	SCREEN_DMA: {
+		name: "Toggle screen DMA enable/disable",
+		handledInKeyboardIrq: true,
+	},
+	SELECT: {
+		name: "Select",
+		notes: [
+			"Read directly from the CONSOL register ($D01F); no fixed OS function.",
+			"On the XEGS, the power-on console keys choose the boot target: the default is the built-in Missile Command with no keyboard attached, or the computer (BASIC) with a keyboard attached. SELECT inverts that default, OPTION alone disables both BASIC and Missile Command, and OPTION+SELECT together restore the default. START still forces a cassette boot in every case (in game mode it enables Missile Command rather than launching it directly).",
+		],
+	},
+	SHIFT: {
+		name: "Shift",
+		pcKeyEquivalent: "Shift",
+		notes: ["Modifier: selects each key's shifted character or function."],
+	},
+	START: {
+		name: "Start",
+		notes: [
+			"Read directly from the CONSOL register ($D01F); no fixed OS function.",
+			"Held at power-on, boots from cassette instead of disk.",
+		],
+	},
+} satisfies Record<string, KeyFunction>;
+
+// A key into the FUNCTIONS table above.
+export type FunctionRef = keyof typeof FUNCTIONS;
+
+export interface Key {
+	name: string;
+	labels: [primary: string, secondary?: string, tertiary?: string];
+	pokeyCode?: number;
+	consoleBit?: number;
+	row: number; // 0..3: normal rows, 4: space, 5: console, 6: F1-F4.
+	column: number; // Index in the row
+	function?: FunctionRef; // Absent for modifiers (SHIFT/CONTROL) and console keys.
+	withShift?: FunctionRef;
+	withControl?: FunctionRef;
+	isControlAndShiftScannable?: boolean;
+	notes?: string[]; // Layout/labeling differences between Atari models.
+}
+
+export const KEYS: Key[] = [
+	{
+		name: "ESC",
+		labels: ["ESC"],
+		row: 0,
+		column: 0,
+		pokeyCode: 0x1c, // 28
+		function: "0x1b",
+		withShift: "0x1b",
+		withControl: "0x1b",
+	},
+	{
+		name: "1",
+		labels: ["1", "!"],
+		row: 0,
+		column: 1,
+		pokeyCode: 0x1f, // 31
+		function: "1",
+		withShift: "!",
+		withControl: "PAUSE",
+	},
+	{
+		name: "2",
+		labels: ["2", '"'],
+		row: 0,
+		column: 2,
+		pokeyCode: 0x1e, // 30
+		function: "2",
+		withShift: '"',
+		withControl: "0xfd",
+	},
+	{
+		name: "3",
+		labels: ["3", "#"],
+		row: 0,
+		column: 3,
+		pokeyCode: 0x1a, // 26
+		function: "3",
+		withShift: "#",
+		withControl: "0x85",
+	},
+	{
+		name: "4",
+		labels: ["4", "$"],
+		row: 0,
+		column: 4,
+		pokeyCode: 0x18, // 24
+		function: "4",
+		withShift: "$",
+	},
+	{
+		name: "5",
+		labels: ["5", "%"],
+		row: 0,
+		column: 5,
+		pokeyCode: 0x1d, // 29
+		function: "5",
+		withShift: "%",
+	},
+	{
+		name: "6",
+		labels: ["6", "&"],
+		row: 0,
+		column: 6,
+		pokeyCode: 0x1b, // 27
+		function: "6",
+		withShift: "&",
+	},
+	{
+		name: "7",
+		labels: ["7", "'"],
+		row: 0,
+		column: 7,
+		pokeyCode: 0x33, // 51
+		function: "7",
+		withShift: "'",
+	},
+	{
+		name: "8",
+		labels: ["8", "@"],
+		row: 0,
+		column: 8,
+		pokeyCode: 0x35, // 53
+		function: "8",
+		withShift: "@",
+	},
+	{
+		name: "9",
+		labels: ["9", "("],
+		row: 0,
+		column: 9,
+		pokeyCode: 0x30, // 48
+		function: "9",
+		withShift: "(",
+	},
+	{
+		name: "0",
+		labels: ["0", ")"],
+		row: 0,
+		column: 10,
+		pokeyCode: 0x32, // 50
+		function: "0",
+		withShift: ")",
+	},
+	{
+		name: "<",
+		labels: ["<", "CLEAR"],
+		row: 0,
+		column: 11,
+		pokeyCode: 0x36, // 54
+		function: "<",
+		withShift: "0x7d",
+		withControl: "0x7d",
+	},
+	{
+		name: ">",
+		labels: [">", "INSERT"],
+		row: 0,
+		column: 12,
+		pokeyCode: 0x37, // 55
+		function: ">",
+		withShift: "0x9d",
+		withControl: "0xff",
+	},
+	{
+		name: "BACK SPACE",
+		labels: ["BACK SPACE", "DELETE"],
+		row: 0,
+		column: 13,
+		pokeyCode: 0x34, // 52
+		function: "0x7e",
+		withShift: "0x9c",
+		withControl: "0xfe",
+		notes: ['Labeled "BACK S" on the 400/800 and "Bk Sp" on the XE.'],
+	},
+	{
+		name: "BREAK",
+		labels: ["BREAK"],
+		row: 0,
+		column: 14,
+		function: "BREAK",
+		notes: ["Moved to the console row on the 1200XL."],
+	},
+	{
+		name: "TAB",
+		labels: ["TAB", "SET", "CLR"],
+		row: 1,
+		column: 0,
+		pokeyCode: 0x2c, // 44
+		function: "0x7f",
+		withShift: "0x9f",
+		withControl: "0x9e",
+	},
+	{
+		name: "Q",
+		labels: ["Q"],
+		row: 1,
+		column: 1,
+		pokeyCode: 0x2f, // 47
+		function: "q",
+		withShift: "Q",
+		withControl: "0x11",
+	},
+	{
+		name: "W",
+		labels: ["W"],
+		row: 1,
+		column: 2,
+		pokeyCode: 0x2e, // 46
+		function: "w",
+		withShift: "W",
+		withControl: "0x17",
+	},
+	{
+		name: "E",
+		labels: ["E"],
+		row: 1,
+		column: 3,
+		pokeyCode: 0x2a, // 42
+		function: "e",
+		withShift: "E",
+		withControl: "0x05",
+	},
+	{
+		name: "R",
+		labels: ["R"],
+		row: 1,
+		column: 4,
+		pokeyCode: 0x28, // 40
+		function: "r",
+		withShift: "R",
+		withControl: "0x12",
+	},
+	{
+		name: "T",
+		labels: ["T"],
+		row: 1,
+		column: 5,
+		pokeyCode: 0x2d, // 45
+		function: "t",
+		withShift: "T",
+		withControl: "0x14",
+	},
+	{
+		name: "Y",
+		labels: ["Y"],
+		row: 1,
+		column: 6,
+		pokeyCode: 0x2b, // 43
+		function: "y",
+		withShift: "Y",
+		withControl: "0x19",
+	},
+	{
+		name: "U",
+		labels: ["U"],
+		row: 1,
+		column: 7,
+		pokeyCode: 0x0b, // 11
+		function: "u",
+		withShift: "U",
+		withControl: "0x15",
+	},
+	{
+		name: "I",
+		labels: ["I"],
+		row: 1,
+		column: 8,
+		pokeyCode: 0x0d, // 13
+		function: "i",
+		withShift: "I",
+		withControl: "0x09",
+	},
+	{
+		name: "O",
+		labels: ["O"],
+		row: 1,
+		column: 9,
+		pokeyCode: 0x08, // 8
+		function: "o",
+		withShift: "O",
+		withControl: "0x0f",
+	},
+	{
+		name: "P",
+		labels: ["P"],
+		row: 1,
+		column: 10,
+		pokeyCode: 0x0a, // 10
+		function: "p",
+		withShift: "P",
+		withControl: "0x10",
+	},
+	{
+		name: "-",
+		labels: ["-", "_", "↑"],
+		row: 1,
+		column: 11,
+		pokeyCode: 0x0e, // 14
+		function: "-",
+		withShift: "_",
+		withControl: "0x1c",
+	},
+	{
+		name: "=",
+		labels: ["=", "|", "↓"],
+		row: 1,
+		column: 12,
+		pokeyCode: 0x0f, // 15
+		function: "=",
+		withShift: "|",
+		withControl: "0x1d",
+	},
+	{
+		name: "RETURN",
+		labels: ["RETURN"],
+		row: 1,
+		column: 13,
+		pokeyCode: 0x0c, // 12
+		function: "0x9b",
+		withShift: "0x9b",
+		withControl: "0x9b",
+	},
+	{
+		name: "CONTROL",
+		labels: ["CONTROL"],
+		row: 2,
+		column: 0,
+		function: "CONTROL",
+		notes: ['Labeled "CTRL" on the 400/800.'],
+	},
+	{
+		name: "A",
+		labels: ["A"],
+		row: 2,
+		column: 1,
+		pokeyCode: 0x3f, // 63
+		function: "a",
+		withShift: "A",
+		withControl: "0x01",
+	},
+	{
+		name: "S",
+		labels: ["S"],
+		row: 2,
+		column: 2,
+		pokeyCode: 0x3e, // 62
+		function: "s",
+		withShift: "S",
+		withControl: "0x13",
+	},
+	{
+		name: "D",
+		labels: ["D"],
+		row: 2,
+		column: 3,
+		pokeyCode: 0x3a, // 58
+		function: "d",
+		withShift: "D",
+		withControl: "0x04",
+	},
+	{
+		name: "F",
+		labels: ["F"],
+		row: 2,
+		column: 4,
+		pokeyCode: 0x38, // 56
+		function: "f",
+		withShift: "F",
+		withControl: "0x06",
+	},
+	{
+		name: "G",
+		labels: ["G"],
+		row: 2,
+		column: 5,
+		pokeyCode: 0x3d, // 61
+		function: "g",
+		withShift: "G",
+		withControl: "0x07",
+	},
+	{
+		name: "H",
+		labels: ["H"],
+		row: 2,
+		column: 6,
+		pokeyCode: 0x39, // 57
+		function: "h",
+		withShift: "H",
+		withControl: "0x08",
+	},
+	{
+		name: "J",
+		labels: ["J"],
+		row: 2,
+		column: 7,
+		pokeyCode: 0x01, // 1
+		function: "j",
+		withShift: "J",
+		withControl: "0x0a",
+		isControlAndShiftScannable: false,
+	},
+	{
+		name: "K",
+		labels: ["K"],
+		row: 2,
+		column: 8,
+		pokeyCode: 0x05, // 5
+		function: "k",
+		withShift: "K",
+		withControl: "0x0b",
+		isControlAndShiftScannable: false,
+	},
+	{
+		name: "L",
+		labels: ["L"],
+		row: 2,
+		column: 9,
+		pokeyCode: 0x00, // 0
+		function: "l",
+		withShift: "L",
+		withControl: "0x0c",
+		isControlAndShiftScannable: false,
+	},
+	{
+		name: ";",
+		labels: [";", ":"],
+		row: 2,
+		column: 10,
+		pokeyCode: 0x02, // 2
+		function: ";",
+		withShift: ":",
+		withControl: "0x7b",
+		isControlAndShiftScannable: false,
+	},
+	{
+		name: "+",
+		labels: ["+", "\\", "←"],
+		row: 2,
+		column: 11,
+		pokeyCode: 0x06, // 6
+		function: "+",
+		withShift: "\\",
+		withControl: "0x1e",
+		isControlAndShiftScannable: false,
+	},
+	{
+		name: "*",
+		labels: ["*", "^", "→"],
+		row: 2,
+		column: 12,
+		pokeyCode: 0x07, // 7
+		function: "*",
+		withShift: "^",
+		withControl: "0x1f",
+		isControlAndShiftScannable: false,
+	},
+	{
+		name: "CAPS",
+		labels: ["CAPS"],
+		row: 2,
+		column: 13,
+		pokeyCode: 0x3c, // 60
+		function: "0x82",
+		withShift: "0x83",
+		withControl: "0x84",
+		notes: [
+			'On the 400/800, the primary label is "LOWR" and CAPS is the secondary label.',
+		],
+	},
+	{
+		name: "SHIFT",
+		labels: ["SHIFT"],
+		row: 3,
+		column: 0,
+		function: "SHIFT",
+	},
+	{
+		name: "Z",
+		labels: ["Z"],
+		row: 3,
+		column: 1,
+		pokeyCode: 0x17, // 23
+		function: "z",
+		withShift: "Z",
+		withControl: "0x1a",
+		isControlAndShiftScannable: false,
+	},
+	{
+		name: "X",
+		labels: ["X"],
+		row: 3,
+		column: 2,
+		pokeyCode: 0x16, // 22
+		function: "x",
+		withShift: "X",
+		withControl: "0x18",
+		isControlAndShiftScannable: false,
+	},
+	{
+		name: "C",
+		labels: ["C"],
+		row: 3,
+		column: 3,
+		pokeyCode: 0x12, // 18
+		function: "c",
+		withShift: "C",
+		withControl: "0x03",
+		isControlAndShiftScannable: false,
+	},
+	{
+		name: "V",
+		labels: ["V"],
+		row: 3,
+		column: 4,
+		pokeyCode: 0x10, // 16
+		function: "v",
+		withShift: "V",
+		withControl: "0x16",
+		isControlAndShiftScannable: false,
+	},
+	{
+		name: "B",
+		labels: ["B"],
+		row: 3,
+		column: 5,
+		pokeyCode: 0x15, // 21
+		function: "b",
+		withShift: "B",
+		withControl: "0x02",
+		isControlAndShiftScannable: false,
+	},
+	{
+		name: "N",
+		labels: ["N"],
+		row: 3,
+		column: 6,
+		pokeyCode: 0x23, // 35
+		function: "n",
+		withShift: "N",
+		withControl: "0x0e",
+	},
+	{
+		name: "M",
+		labels: ["M"],
+		row: 3,
+		column: 7,
+		pokeyCode: 0x25, // 37
+		function: "m",
+		withShift: "M",
+		withControl: "0x0d",
+	},
+	{
+		name: ",",
+		labels: [",", "["],
+		row: 3,
+		column: 8,
+		pokeyCode: 0x20, // 32
+		function: ",",
+		withShift: "[",
+		withControl: "0x00",
+	},
+	{
+		name: ".",
+		labels: [".", "]"],
+		row: 3,
+		column: 9,
+		pokeyCode: 0x22, // 34
+		function: ".",
+		withShift: "]",
+		withControl: "0x60",
+	},
+	{
+		name: "/",
+		labels: ["/", "?"],
+		row: 3,
+		column: 10,
+		pokeyCode: 0x26, // 38
+		function: "/",
+		withShift: "?",
+	},
+	{
+		name: "◩",
+		labels: ["◩"],
+		row: 3,
+		column: 11,
+		pokeyCode: 0x27, // 39
+		function: "0x81",
+		withShift: "0x81",
+		withControl: "0x81",
+		notes: [
+			"On the 400/800, labeled with the Atari Fuji logo.",
+			"Moved to the console row on the 1200XL.",
+			"Swapped with the adjacent right SHIFT between the 400/800 and XL/XE.",
+		],
+	},
+	{
+		name: "SHIFT",
+		labels: ["SHIFT"],
+		row: 3,
+		column: 12,
+		function: "SHIFT",
+		notes: ["Swapped with the adjacent ◩ key between the 400/800 and XL/XE."],
+	},
+	{
+		name: "SPACE",
+		labels: ["SPACE"],
+		row: 4,
+		column: 0,
+		pokeyCode: 0x21, // 33
+		function: " ",
+		withShift: " ",
+		withControl: " ",
+	},
+	{
+		name: "RESET",
+		labels: ["RESET"],
+		row: 5,
+		column: 0,
+		function: "RESET",
+		notes: ['Labeled "SYSTEM RESET" on the 400/800.'],
+	},
+	{
+		name: "OPTION",
+		labels: ["OPTION"],
+		row: 5,
+		column: 1,
+		function: "OPTION",
+		consoleBit: 2,
+	},
+	{
+		name: "SELECT",
+		labels: ["SELECT"],
+		row: 5,
+		column: 2,
+		function: "SELECT",
+		consoleBit: 1,
+	},
+	{
+		name: "START",
+		labels: ["START"],
+		row: 5,
+		column: 3,
+		function: "START",
+		consoleBit: 0,
+	},
+	{
+		name: "HELP",
+		labels: ["HELP"],
+		row: 5,
+		column: 4,
+		pokeyCode: 0x11, // 17
+		function: "HELP",
+		isControlAndShiftScannable: false,
+		notes: ["XL/XE only."],
+	},
+	{
+		name: "F1",
+		labels: ["F1"],
+		row: 6,
+		column: 0,
+		pokeyCode: 0x03, // 3
+		function: "0x1c",
+		withShift: "0x8e",
+		withControl: "KBD_ENABLE",
+		isControlAndShiftScannable: false,
+		notes: ["1200XL only."],
+	},
+	{
+		name: "F2",
+		labels: ["F2"],
+		row: 6,
+		column: 1,
+		pokeyCode: 0x04, // 4
+		function: "0x1d",
+		withShift: "0x8f",
+		withControl: "SCREEN_DMA",
+		isControlAndShiftScannable: false,
+		notes: ["1200XL only."],
+	},
+	{
+		name: "F3",
+		labels: ["F3"],
+		row: 6,
+		column: 2,
+		pokeyCode: 0x13, // 19
+		function: "0x1e",
+		withShift: "0x90",
+		withControl: "0x89",
+		isControlAndShiftScannable: false,
+		notes: ["1200XL only."],
+	},
+	{
+		name: "F4",
+		labels: ["F4"],
+		row: 6,
+		column: 3,
+		pokeyCode: 0x14, // 20
+		function: "0x1f",
+		withShift: "0x91",
+		withControl: "CHARSET",
+		isControlAndShiftScannable: false,
+		notes: ["1200XL only."],
+	},
+];

--- a/apps/a8-web/src/keyboard-lab.ts
+++ b/apps/a8-web/src/keyboard-lab.ts
@@ -1,0 +1,133 @@
+// A scratch page for observing raw keyboard/composition events — not part of
+// the emulator app and not a production build input; served by the dev server
+// at /keyboard-lab.html.
+/* eslint-disable no-console -- logging to the console is this page's whole job */
+
+const MODIFIER_STATES = [
+	"Shift",
+	"Control",
+	"Alt",
+	"Meta",
+	"AltGraph",
+	"CapsLock",
+	"NumLock",
+	"ScrollLock",
+] as const;
+
+const LOCATION_NAMES = ["std", "left", "right", "numpad"] as const;
+
+function quote(value: string | null): string {
+	if (value === null) return "null";
+	// Show whitespace/control chars and their code points explicitly.
+	const points = [...value]
+		.map((char) => "U+" + char.codePointAt(0)!.toString(16).padStart(4, "0"))
+		.join(" ");
+	return `${JSON.stringify(value)} [${points}]`;
+}
+
+function activeModifiers(event: KeyboardEvent): string {
+	const on = MODIFIER_STATES.filter((name) => event.getModifierState(name));
+	return on.length ? on.join("+") : "—";
+}
+
+function describeKeyboard(event: KeyboardEvent): string {
+	const location = LOCATION_NAMES[event.location] ?? String(event.location);
+	return [
+		`key=${quote(event.key)}`,
+		`code=${event.code}`,
+		`loc=${location}`,
+		`repeat=${event.repeat}`,
+		`isComposing=${event.isComposing}`,
+		`mods=[${activeModifiers(event)}]`,
+	].join("  ");
+}
+
+function describeInput(event: InputEvent): string {
+	return [
+		`inputType=${event.inputType}`,
+		`data=${quote(event.data)}`,
+		`isComposing=${event.isComposing}`,
+	].join("  ");
+}
+
+function describeComposition(event: CompositionEvent): string {
+	return `data=${quote(event.data)}`;
+}
+
+function main(): void {
+	const field = document.getElementById("field") as HTMLInputElement;
+	const prevent = document.getElementById("prevent") as HTMLInputElement;
+	const clearField = document.getElementById("clearField") as HTMLInputElement;
+	const clearButton = document.getElementById("clear") as HTMLButtonElement;
+	const modsEl = document.getElementById("mods") as HTMLDivElement;
+	const logEl = document.getElementById("log") as HTMLDivElement;
+
+	let start = performance.now();
+
+	const stamp = (): string =>
+		`+${Math.round(performance.now() - start)
+			.toString()
+			.padStart(5)}ms`;
+
+	const append = (type: string, detail: string, event: Event): void => {
+		const row = document.createElement("div");
+		row.className = `row t-${type}`;
+		row.textContent = `${stamp()}  ${type.padEnd(17)} ${detail}`;
+		logEl.append(row);
+		logEl.scrollIntoView(false);
+		console.log(`[${type}]`, detail, event);
+	};
+
+	const renderMods = (event: KeyboardEvent): void => {
+		modsEl.innerHTML = "";
+		for (const name of MODIFIER_STATES) {
+			const span = document.createElement("span");
+			const on = event.getModifierState(name);
+			span.className = on ? "on" : "dim";
+			span.textContent = `${name}:${on ? "1" : "0"}`;
+			modsEl.append(span, document.createTextNode("  "));
+		}
+	};
+
+	field.addEventListener("keydown", (event) => {
+		renderMods(event);
+		append("keydown", describeKeyboard(event), event);
+		if (prevent.checked) event.preventDefault();
+	});
+
+	field.addEventListener("keyup", (event) => {
+		renderMods(event);
+		append("keyup", describeKeyboard(event), event);
+	});
+
+	field.addEventListener("beforeinput", (event) => {
+		append("beforeinput", describeInput(event as InputEvent), event);
+	});
+
+	field.addEventListener("input", (event) => {
+		append("input", describeInput(event as InputEvent), event);
+		if (clearField.checked && !(event as InputEvent).isComposing) {
+			field.value = "";
+		}
+	});
+
+	for (const type of [
+		"compositionstart",
+		"compositionupdate",
+		"compositionend",
+	] as const) {
+		field.addEventListener(type, (event) => {
+			append(type, describeComposition(event), event);
+			if (type === "compositionend" && clearField.checked) field.value = "";
+		});
+	}
+
+	clearButton.addEventListener("click", () => {
+		logEl.innerHTML = "";
+		start = performance.now();
+	});
+
+	field.focus();
+}
+
+main();

--- a/apps/a8-web/vite.config.ts
+++ b/apps/a8-web/vite.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from "node:url";
 import preact from "@preact/preset-vite";
 import basicSsl from "@vitejs/plugin-basic-ssl";
 import tailwindcss from "@tailwindcss/vite";
@@ -14,6 +15,17 @@ export default defineConfig({
 	// emit them as hashed assets instead of trying to parse them as source.
 	assetsInclude: ["**/*.rom", "**/*.xex", "**/*.atr", "**/*.car"],
 	server: { host: true },
+	// Multi-page build: the emulator (index.html) plus the reference docs
+	// (docs/index.html, served at /docs/). keyboard-lab.html is intentionally
+	// not an input — it stays a dev-only scratch page.
+	build: {
+		rollupOptions: {
+			input: {
+				main: fileURLToPath(new URL("./index.html", import.meta.url)),
+				docs: fileURLToPath(new URL("./docs/index.html", import.meta.url)),
+			},
+		},
+	},
 	// @sfotty-pie/a8 is a linked workspace package built to dist. Excluding it
 	// from dep pre-bundling lets Vite pick up its rebuilds (from the root
 	// `pnpm dev` watch) and reload, instead of serving a stale optimized copy.


### PR DESCRIPTION
Adds an in-app reference at **/docs/** and commits the keyboard event lab dev page.

## /docs/ — keyboard & character-set reference
A new Preact + Tailwind page (its own MPA entry, built and deployed with the app):

- **Keyboard view** — the physical layout with full key legends; hover a key (or click to pin) to see its POKEY scan codes (base / +Shift / +Control / +Shift+Ctrl, with non-scannable combos flagged), model notes, and what each modifier produces (glyph, ATASCII/ANTIC codes with +$80 inverse, intl glyph, pseudo-ATASCII, IRQ handling).
- **ATASCII / ANTIC table** ($00–$7F) — codes (hex+dec, with inverse), glyph + intl alternate, producing key, control-code functions and their inverse forms.
- **Keyboard codes table** — POKEY scan code per key plus the KBCODE for each modifier combination.
- **Keyboard matrix** — the 8×8 scan-code grid, with Control/Shift/Break shown on their co-scanned codes.

Backed by `src/keyboard-docs.ts` (`FUNCTIONS` + `KEYS`), a self-contained, deduplicated data model.

## keyboard-lab.html
A dev-only scratch page (served at `/keyboard-lab.html`, not a production build input) that logs raw keyboard/composition events — now committed rather than left untracked.

Readme updated with a short note on both. Typecheck, lint, and build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)