### PR TITLE
feat(a8-web): ship the keyboard lab in the production build

### DIFF
--- a/apps/a8-web/readme.md
+++ b/apps/a8-web/readme.md
@@ -34,7 +34,7 @@ The headless emulator lives in `@sfotty-pie/a8`; this app is the I/O and chrome 
 ### Reference and dev pages
 
 - **`/docs/`** — a generated reference for the keyboard and the ATASCII/ANTIC character set: a keyboard map (hover, or click a key to pin its scan codes and functions), the full character table, the POKEY scan-code table, and the 8×8 key matrix. Built and deployed with the app; source in [`src/docs/`](src/docs/), data in [`src/keyboard-docs.ts`](src/keyboard-docs.ts).
-- **[`keyboard-lab.html`](keyboard-lab.html)** — a dev-only scratch page (served at `/keyboard-lab.html`, not in the production build) that logs raw `keydown` / `keyup` / `input` / `composition` events, handy for untangling browser keyboard quirks.
+- **[`keyboard-lab.html`](keyboard-lab.html)** — a scratch page (served at `/keyboard-lab.html`) that logs raw `keydown` / `keyup` / `input` / `composition` events, handy for untangling browser keyboard quirks. Built and deployed with the app so its capturability probes can be run on borrowed or remote machines across OSes and browsers.
 
 ## The image library
 
@@ -57,7 +57,7 @@ pnpm --filter @sfotty-pie/a8-web build
 Output is `apps/a8-web/dist/` — plain static files. Notes for hosting:
 
 - **Serve over HTTPS.** Audio (and more later) needs a secure context.
-- It's static pages (`index.html` and `/docs/`) with hashed assets and real files under `/legal/`, so **no SPA-style catch-all redirect** is needed.
+- It's static pages (`index.html`, `/docs/`, and `/keyboard-lab.html`) with hashed assets and real files under `/legal/`, so **no SPA-style catch-all redirect** is needed.
 - The committed build is **firmware-only** — `library.local/` is gitignored, so a clean CI/host build won't include your ROMs or games. Bake those in by populating `library.local/` in your build environment.
 
 Any static host works (e.g. `rsync` the `dist/` to a web root).

--- a/apps/a8-web/vite.config.ts
+++ b/apps/a8-web/vite.config.ts
@@ -15,14 +15,18 @@ export default defineConfig({
 	// emit them as hashed assets instead of trying to parse them as source.
 	assetsInclude: ["**/*.rom", "**/*.xex", "**/*.atr", "**/*.car"],
 	server: { host: true },
-	// Multi-page build: the emulator (index.html) plus the reference docs
-	// (docs/index.html, served at /docs/). keyboard-lab.html is intentionally
-	// not an input — it stays a dev-only scratch page.
+	// Multi-page build: the emulator (index.html), the reference docs
+	// (docs/index.html, served at /docs/), and the keyboard event lab
+	// (keyboard-lab.html, served at /keyboard-lab.html) — shipped so its
+	// capturability probes can be run on borrowed/remote machines.
 	build: {
 		rollupOptions: {
 			input: {
 				main: fileURLToPath(new URL("./index.html", import.meta.url)),
 				docs: fileURLToPath(new URL("./docs/index.html", import.meta.url)),
+				keyboardLab: fileURLToPath(
+					new URL("./keyboard-lab.html", import.meta.url),
+				),
 			},
 		},
 	},


### PR DESCRIPTION
Adds `keyboard-lab.html` to the Vite multi-page build inputs so it deploys with the app (served at `/keyboard-lab.html`), instead of staying a dev-only scratch page.

Motivation: the key-binding capturability probes need to run on machines I don't have a dev server on — a borrowed Windows laptop, plus Mac and Linux Mint boxes — to confirm which modifier combos browsers actually deliver and let `preventDefault`.

- `vite.config.ts`: add `keyboardLab` rollup input; update the comment.
- `readme.md`: drop the "dev-only / not in production build" wording; add it to the static-pages list.

Verified `pnpm --filter @sfotty-pie/a8-web build` emits `dist/keyboard-lab.html` with the script rewritten to the hashed asset.