### PR TITLE
Disk write support and attachment management

### DIFF
--- a/apps/a8-web/src/app.tsx
+++ b/apps/a8-web/src/app.tsx
@@ -81,7 +81,8 @@ export function App({ host }: { host: EmulatorHost }) {
 
 			<Alert host={host} />
 
-			{/* Hidden picker behind the "Boot image…" menu action. */}
+			{/* Hidden picker shared by the boot-image and insert-disk actions;
+			    the host routes the chosen file per the action that opened it. */}
 			<input
 				ref={fileInput}
 				type="file"
@@ -90,7 +91,7 @@ export function App({ host }: { host: EmulatorHost }) {
 				onChange={(event) => {
 					const picker = event.currentTarget;
 					const file = picker.files?.[0];
-					if (file) void host.loadFile(file);
+					if (file) host.handlePickedFile(file);
 					picker.value = ""; // re-picking the same file fires again
 				}}
 			/>

--- a/apps/a8-web/src/bottom-bar.tsx
+++ b/apps/a8-web/src/bottom-bar.tsx
@@ -1,13 +1,21 @@
 import type { EmulatorHost } from "./host.ts";
 
-/** The bottom status bar: the booted image's name and a crash indicator. */
+/** The bottom status bar: the attached cartridge/disks and a crash indicator. */
 export function BottomBar({ host }: { host: EmulatorHost }) {
-	const imageName = host.imageName.value;
+	const { cartridge, drives } = host.attachments.value;
 	const crashed = host.crashed.value;
 
 	return (
 		<footer class="flex h-7 shrink-0 items-center gap-4 px-3 text-sm text-neutral-400">
-			<span class="truncate">{imageName ?? ""}</span>
+			{cartridge && <span class="truncate">Cart: {cartridge}</span>}
+			{drives.map(
+				(name, index) =>
+					name && (
+						<span key={index} class="truncate">
+							D{index + 1}: {name}
+						</span>
+					),
+			)}
 			{crashed && (
 				<span class="ml-auto font-semibold text-red-500">
 					CPU crashed (CIM)

--- a/apps/a8-web/src/commands.ts
+++ b/apps/a8-web/src/commands.ts
@@ -68,6 +68,13 @@ export const commands = {
 	// Boot a file as a fresh machine image (opens the file picker).
 	BOOT_IMAGE: { label: "BOOT_IMAGE", run: ({ host }) => host.pickBootImage() },
 
+	// Insert a disk into D1: of the running machine (no reboot, BASIC kept).
+	INSERT_D1: { label: "INSERT_D1", run: ({ host }) => host.pickInsertDisk() },
+	// Remove the disk from D1: (live).
+	REMOVE_D1: { label: "REMOVE_D1", run: ({ host }) => host.removeDisk() },
+	// Save the D1: disk (with any in-session writes) to a file.
+	DOWNLOAD_D1: { label: "DOWNLOAD_D1", run: ({ host }) => host.downloadDisk() },
+
 	// Machine configuration. Each applies the change and reboots into it
 	// immediately. (The menu's config form does its own stage/apply instead, so
 	// the palette stays a one-shot surface.)
@@ -520,6 +527,9 @@ export const labels = {
 	AUDIO_TOGGLE: "Toggle audio (enable, then mute/unmute)",
 	MENU_TOGGLE: "Toggle the menu",
 	BOOT_IMAGE: "Boot a disk, cartridge, or executable…",
+	INSERT_D1: "Insert a disk into D1: (no reboot)…",
+	REMOVE_D1: "Remove the disk from D1:",
+	DOWNLOAD_D1: "Download the D1: disk image…",
 	SET_TYPE_800: "Set machine type to Atari 800 (reboots)",
 	SET_TYPE_800XL: "Set machine type to Atari 800XL (reboots)",
 	SET_TYPE_130XE: "Set machine type to Atari 130XE (reboots)",

--- a/apps/a8-web/src/commands.ts
+++ b/apps/a8-web/src/commands.ts
@@ -72,6 +72,15 @@ export const commands = {
 	ATTACH_D1: { label: "ATTACH_D1", run: ({ host }) => host.pickAttachDisk() },
 	// Detach the disk from D1: (live).
 	DETACH_D1: { label: "DETACH_D1", run: ({ host }) => host.detachDisk() },
+	// Attach/detach a cartridge (cold boots; leaves other media in place).
+	ATTACH_CARTRIDGE: {
+		label: "ATTACH_CARTRIDGE",
+		run: ({ host }) => host.pickAttachCartridge(),
+	},
+	DETACH_CARTRIDGE: {
+		label: "DETACH_CARTRIDGE",
+		run: ({ host }) => host.detachCartridge(),
+	},
 	// Save the D1: disk (with any in-session writes) to a file.
 	DOWNLOAD_D1: { label: "DOWNLOAD_D1", run: ({ host }) => host.downloadDisk() },
 
@@ -529,6 +538,8 @@ export const labels = {
 	BOOT_IMAGE: "Boot a disk, cartridge, or executable…",
 	ATTACH_D1: "Attach a disk to D1:…",
 	DETACH_D1: "Detach the disk from D1:",
+	ATTACH_CARTRIDGE: "Attach a cartridge… (reboots)",
+	DETACH_CARTRIDGE: "Detach the cartridge (reboots)",
 	DOWNLOAD_D1: "Download the D1: disk image…",
 	SET_TYPE_800: "Set machine type to Atari 800 (reboots)",
 	SET_TYPE_800XL: "Set machine type to Atari 800XL (reboots)",

--- a/apps/a8-web/src/commands.ts
+++ b/apps/a8-web/src/commands.ts
@@ -68,10 +68,10 @@ export const commands = {
 	// Boot a file as a fresh machine image (opens the file picker).
 	BOOT_IMAGE: { label: "BOOT_IMAGE", run: ({ host }) => host.pickBootImage() },
 
-	// Insert a disk into D1: of the running machine (no reboot, BASIC kept).
-	INSERT_D1: { label: "INSERT_D1", run: ({ host }) => host.pickInsertDisk() },
-	// Remove the disk from D1: (live).
-	REMOVE_D1: { label: "REMOVE_D1", run: ({ host }) => host.removeDisk() },
+	// Attach a disk to D1: of the running machine (no reboot, BASIC kept).
+	ATTACH_D1: { label: "ATTACH_D1", run: ({ host }) => host.pickAttachDisk() },
+	// Detach the disk from D1: (live).
+	DETACH_D1: { label: "DETACH_D1", run: ({ host }) => host.detachDisk() },
 	// Save the D1: disk (with any in-session writes) to a file.
 	DOWNLOAD_D1: { label: "DOWNLOAD_D1", run: ({ host }) => host.downloadDisk() },
 
@@ -527,8 +527,8 @@ export const labels = {
 	AUDIO_TOGGLE: "Toggle audio (enable, then mute/unmute)",
 	MENU_TOGGLE: "Toggle the menu",
 	BOOT_IMAGE: "Boot a disk, cartridge, or executable…",
-	INSERT_D1: "Insert a disk into D1: (no reboot)…",
-	REMOVE_D1: "Remove the disk from D1:",
+	ATTACH_D1: "Attach a disk to D1:…",
+	DETACH_D1: "Detach the disk from D1:",
 	DOWNLOAD_D1: "Download the D1: disk image…",
 	SET_TYPE_800: "Set machine type to Atari 800 (reboots)",
 	SET_TYPE_800XL: "Set machine type to Atari 800XL (reboots)",

--- a/apps/a8-web/src/host.ts
+++ b/apps/a8-web/src/host.ts
@@ -185,9 +185,15 @@ export class EmulatorHost {
 	// XL/XE BASIC is internal and isn't shown.
 	#refreshAttachments(): void {
 		const { model, basicDisabled } = this.config.value;
-		const basicInSlot = model === "800" && !basicDisabled;
+		// On the 400/800 an enabled BASIC is a real cartridge in the slot, so
+		// show the actual ROM image's name; on XL/XE BASIC is internal and the
+		// slot reflects only a real cartridge.
+		const basic =
+			model === "800" && !basicDisabled
+				? (this.#pick(preferredBasicKeys())?.entry.fileName ?? null)
+				: null;
 		this.attachments.value = {
-			cartridge: this.#cartridge?.name ?? (basicInSlot ? "BASIC" : null),
+			cartridge: this.#cartridge?.name ?? basic,
 			drives: this.#drives.map((drive) => drive?.name ?? null),
 		};
 	}
@@ -358,6 +364,12 @@ export class EmulatorHost {
 	/** Open the file picker to attach a disk to D1: (no reboot). */
 	pickAttachDisk(): void {
 		this.#pendingPick = (file) => void this.attachDiskFile(file);
+		this.#bootImagePicker?.();
+	}
+
+	/** Open the file picker to attach a cartridge (cold boots). */
+	pickAttachCartridge(): void {
+		this.#pendingPick = (file) => void this.attachCartridgeFile(file);
 		this.#bootImagePicker?.();
 	}
 
@@ -562,6 +574,64 @@ export class EmulatorHost {
 		this.#drives[0] = null;
 		this.#emulator.machine.ejectDisk();
 		this.#refreshAttachments();
+	}
+
+	/**
+	 * Attach a cartridge and cold boot into it. Unlike Boot image this leaves
+	 * the other media in place (a disk in D1: stays, and the cart's own header
+	 * flags then decide whether the disk also boots). It reboots because a
+	 * cartridge is memory-mapped and only takes effect at reset; the niche
+	 * "stage it without rebooting" can come later.
+	 */
+	async attachCartridgeFile(file: File): Promise<void> {
+		const contents = new Uint8Array(await file.arrayBuffer());
+		const format = detectFileFormat(contents, file.name);
+		const isCartridge =
+			format !== null &&
+			format !== "atr" &&
+			format !== "xex" &&
+			unsupportedMessage(format) === null;
+		if (!isCartridge) {
+			this.alert.value = `${file.name}: not a cartridge image`;
+			return;
+		}
+
+		let cart: Cartridge;
+		try {
+			cart = new Cartridge(contents, file.name);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			this.alert.value = `${file.name}: ${message}`;
+			return;
+		}
+
+		this.sidebar.value = null; // get out of the way
+		this.#cartridge = { cart, name: file.name };
+		this.#refreshAttachments();
+		this.#rebuild();
+	}
+
+	/**
+	 * Clear the cartridge slot and cold boot (other media stays in place). With
+	 * an explicit cart in it, detach the cart. Otherwise, only on the 400/800
+	 * where an enabled BASIC fills the slot, disable BASIC instead (it reboots
+	 * too) — what the user means by "detach." Anything else (XL/XE, or the slot
+	 * already empty) has nothing to remove, so it reports that. (A confirmation
+	 * step can come later.)
+	 */
+	detachCartridge(): void {
+		if (this.#cartridge) {
+			this.#cartridge = null;
+			this.#refreshAttachments();
+			this.#rebuild();
+			return;
+		}
+		const { model, basicDisabled } = this.config.value;
+		if (model === "800" && !basicDisabled) {
+			this.applyBasicDisabled(true);
+			return;
+		}
+		this.alert.value = "No cartridge to detach.";
 	}
 
 	/**

--- a/apps/a8-web/src/host.ts
+++ b/apps/a8-web/src/host.ts
@@ -136,6 +136,8 @@ export class EmulatorHost {
 	#emulator: Emulator;
 	#keyInput: HTMLInputElement | null = null;
 	#bootImagePicker: (() => void) | null = null;
+	// What to do with the next file the shared picker yields (boot vs. insert).
+	#pendingPick: (file: File) => void = (file) => void this.loadFile(file);
 	#cpuTrace = false; // persists across reboots; reapplied to each emulator
 	#turboMode = false; // persists across reboots; reapplied to each emulator
 	// The currently mounted image (kept across reboots; replaced by a Load).
@@ -321,7 +323,19 @@ export class EmulatorHost {
 	}
 
 	pickBootImage(): void {
+		this.#pendingPick = (file) => void this.loadFile(file);
 		this.#bootImagePicker?.();
+	}
+
+	/** Open the file picker to insert a disk into D1: (no reboot). */
+	pickInsertDisk(): void {
+		this.#pendingPick = (file) => void this.insertDiskFile(file);
+		this.#bootImagePicker?.();
+	}
+
+	/** The shared picker's callback: route the chosen file per the last pick. */
+	handlePickedFile(file: File): void {
+		this.#pendingPick(file);
 	}
 
 	dismissAlert(): void {
@@ -456,6 +470,72 @@ export class EmulatorHost {
 		this.imageName.value = name;
 		this.config.value = { ...this.config.value, basicDisabled: true };
 		this.#rebuild();
+	}
+
+	/**
+	 * Save the disk mounted in D1: as an `.atr`, including any sectors the
+	 * running machine has written this session (writes live only in memory, so
+	 * this is how you keep them). Writable disks only — the synthetic XEX boot
+	 * disk is write-protected and isn't a real disk worth saving.
+	 */
+	downloadDisk(): void {
+		const attachment = this.#attachment;
+		if (
+			!attachment ||
+			!("disk" in attachment) ||
+			attachment.disk.writeProtected
+		) {
+			this.alert.value = "No writable disk in D1: to download.";
+			return;
+		}
+
+		// Copy into a fresh ArrayBuffer-backed view: a snapshot the Blob owns,
+		// decoupled from later writes to the live image.
+		const blob = new Blob([new Uint8Array(attachment.disk.toBytes())], {
+			type: "application/octet-stream",
+		});
+		const url = URL.createObjectURL(blob);
+		const anchor = document.createElement("a");
+		anchor.href = url;
+		anchor.download = this.imageName.value ?? "disk.atr";
+		anchor.click();
+		URL.revokeObjectURL(url);
+	}
+
+	/**
+	 * Insert an ATR into D1: of the running machine — live, no reboot, BASIC
+	 * untouched (unlike Boot image, which power-cycles into the image). The
+	 * disk also becomes D1: for the next cold start and is what Download D1:
+	 * saves. (Single attachment slot for now: this replaces any mounted
+	 * cartridge in the persisted set, though the running machine keeps it
+	 * until the next reboot.)
+	 */
+	async insertDiskFile(file: File): Promise<void> {
+		const contents = new Uint8Array(await file.arrayBuffer());
+		let disk: AtrImage;
+		try {
+			disk = new AtrImage(contents);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			this.alert.value = `${file.name}: ${message}`;
+			return;
+		}
+
+		this.#attachment = { disk };
+		this.imageName.value = file.name;
+		this.#emulator.machine.insertDisk(disk);
+		this.sidebar.value = null; // get out of the way
+	}
+
+	/** Remove the disk from D1: of the running machine (live, no reboot). */
+	removeDisk(): void {
+		if (!this.#attachment || !("disk" in this.#attachment)) {
+			this.alert.value = "No disk in D1: to remove.";
+			return;
+		}
+		this.#attachment = null;
+		this.imageName.value = null;
+		this.#emulator.machine.ejectDisk();
 	}
 
 	/**

--- a/apps/a8-web/src/host.ts
+++ b/apps/a8-web/src/host.ts
@@ -83,8 +83,15 @@ function unsupportedMessage(format: AtariFileFormat | null): string | null {
  * touch Preact's render path.
  */
 export class EmulatorHost {
-	/** The last successfully booted image's name (null = nothing loaded). */
-	readonly imageName = signal<string | null>(null);
+	/**
+	 * What's attached, for the status bar: the cartridge-slot label (a cart
+	 * name, or "BASIC" when it occupies the 400/800 cart slot, or null) and a
+	 * per-drive disk name (index 0 = D1:; null = empty).
+	 */
+	readonly attachments = signal<{
+		cartridge: string | null;
+		drives: (string | null)[];
+	}>({ cartridge: null, drives: [null] });
 
 	/** True once the CPU has jammed (CIM). */
 	readonly crashed = signal(false);
@@ -136,12 +143,15 @@ export class EmulatorHost {
 	#emulator: Emulator;
 	#keyInput: HTMLInputElement | null = null;
 	#bootImagePicker: (() => void) | null = null;
-	// What to do with the next file the shared picker yields (boot vs. insert).
+	// What to do with the next file the shared picker yields (boot vs. attach).
 	#pendingPick: (file: File) => void = (file) => void this.loadFile(file);
 	#cpuTrace = false; // persists across reboots; reapplied to each emulator
 	#turboMode = false; // persists across reboots; reapplied to each emulator
-	// The currently mounted image (kept across reboots; replaced by a Load).
-	#attachment: { cartridge: Cartridge } | { disk: AtrImage } | null = null;
+	// What's mounted, kept across reboots and re-applied by #makeEmulator. The
+	// cartridge slot and the disk drives are independent (a cart and a disk can
+	// coexist); #drives is indexed by drive number (0 = D1:), one slot for now.
+	#cartridge: { cart: Cartridge; name: string } | null = null;
+	#drives: ({ disk: AtrImage; name: string } | null)[] = [null];
 
 	constructor({ model, firmware, audio, audioError }: HostConfig) {
 		// Later firmware of the same key wins; the library is already merged
@@ -162,6 +172,24 @@ export class EmulatorHost {
 			);
 			this.#refreshAudioState();
 		}
+
+		// Keep the status-bar attachment labels in sync with the config — the
+		// 400/800 BASIC slot depends on the model and whether BASIC is enabled.
+		// (Runs immediately, seeding the initial labels.)
+		this.config.subscribe(() => this.#refreshAttachments());
+	}
+
+	// Recompute the status-bar attachment labels from the mounted slots and the
+	// running config. On the 400/800 an enabled BASIC occupies the cartridge
+	// slot (when no cart is mounted) and shows there like any cartridge; on
+	// XL/XE BASIC is internal and isn't shown.
+	#refreshAttachments(): void {
+		const { model, basicDisabled } = this.config.value;
+		const basicInSlot = model === "800" && !basicDisabled;
+		this.attachments.value = {
+			cartridge: this.#cartridge?.name ?? (basicInSlot ? "BASIC" : null),
+			drives: this.#drives.map((drive) => drive?.name ?? null),
+		};
 	}
 
 	/** Run a bound command (from a key binding, the UI, or the palette). */
@@ -198,8 +226,7 @@ export class EmulatorHost {
 	#makeEmulator(): Emulator {
 		const { model, tv, basicDisabled } = this.config.value;
 		const xl = model !== "800";
-		const cartMounted =
-			this.#attachment !== null && "cartridge" in this.#attachment;
+		const cartMounted = this.#cartridge !== null;
 		const includeBasic = xl || (!basicDisabled && !cartMounted);
 
 		const os = this.#pick(preferredOsKeys({ model, tv }));
@@ -222,7 +249,8 @@ export class EmulatorHost {
 			tvSystem: tv,
 			...(basic && { basic: basic.bytes }),
 			...(xl && basicDisabled && { holdOption: true }),
-			...this.#attachment,
+			...(this.#cartridge && { cartridge: this.#cartridge.cart }),
+			...(this.#drives[0] && { disk: this.#drives[0].disk }),
 			...(this.#audio && { audio: this.#audio }),
 		});
 		emulator.setTrace(this.#cpuTrace);
@@ -327,9 +355,9 @@ export class EmulatorHost {
 		this.#bootImagePicker?.();
 	}
 
-	/** Open the file picker to insert a disk into D1: (no reboot). */
-	pickInsertDisk(): void {
-		this.#pendingPick = (file) => void this.insertDiskFile(file);
+	/** Open the file picker to attach a disk to D1: (no reboot). */
+	pickAttachDisk(): void {
+		this.#pendingPick = (file) => void this.attachDiskFile(file);
 		this.#bootImagePicker?.();
 	}
 
@@ -449,16 +477,19 @@ export class EmulatorHost {
 			return;
 		}
 
-		let attachment: { cartridge: Cartridge } | { disk: AtrImage };
+		// Boot image starts fresh: fill the one slot it boots from and clear the
+		// rest. (Attach, below, instead adds to the running machine in place.)
+		let cartridge: { cart: Cartridge; name: string } | null = null;
+		let disk: { disk: AtrImage; name: string } | null = null;
 		try {
-			attachment =
-				format === "atr"
-					? { disk: new AtrImage(contents) }
-					: format === "xex"
-						? // XEX files boot from a generated in-memory disk whose
-							// boot sectors are the XEX loader.
-							{ disk: buildBootDisk(contents) }
-						: { cartridge: new Cartridge(contents, name) };
+			if (format === "atr") {
+				disk = { disk: new AtrImage(contents), name };
+			} else if (format === "xex") {
+				// XEX boots from a generated in-memory disk (its loader).
+				disk = { disk: buildBootDisk(contents), name };
+			} else {
+				cartridge = { cart: new Cartridge(contents, name), name };
+			}
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			this.alert.value = `${name}: ${message}`;
@@ -466,9 +497,10 @@ export class EmulatorHost {
 		}
 
 		this.sidebar.value = null; // get out of the way
-		this.#attachment = attachment;
-		this.imageName.value = name;
+		this.#cartridge = cartridge;
+		this.#drives = [disk];
 		this.config.value = { ...this.config.value, basicDisabled: true };
+		this.#refreshAttachments();
 		this.#rebuild();
 	}
 
@@ -479,38 +511,32 @@ export class EmulatorHost {
 	 * disk is write-protected and isn't a real disk worth saving.
 	 */
 	downloadDisk(): void {
-		const attachment = this.#attachment;
-		if (
-			!attachment ||
-			!("disk" in attachment) ||
-			attachment.disk.writeProtected
-		) {
+		const drive = this.#drives[0];
+		if (!drive || drive.disk.writeProtected) {
 			this.alert.value = "No writable disk in D1: to download.";
 			return;
 		}
 
 		// Copy into a fresh ArrayBuffer-backed view: a snapshot the Blob owns,
 		// decoupled from later writes to the live image.
-		const blob = new Blob([new Uint8Array(attachment.disk.toBytes())], {
+		const blob = new Blob([new Uint8Array(drive.disk.toBytes())], {
 			type: "application/octet-stream",
 		});
 		const url = URL.createObjectURL(blob);
 		const anchor = document.createElement("a");
 		anchor.href = url;
-		anchor.download = this.imageName.value ?? "disk.atr";
+		anchor.download = drive.name;
 		anchor.click();
 		URL.revokeObjectURL(url);
 	}
 
 	/**
-	 * Insert an ATR into D1: of the running machine — live, no reboot, BASIC
+	 * Attach an ATR to D1: of the running machine — live, no reboot, BASIC
 	 * untouched (unlike Boot image, which power-cycles into the image). The
 	 * disk also becomes D1: for the next cold start and is what Download D1:
-	 * saves. (Single attachment slot for now: this replaces any mounted
-	 * cartridge in the persisted set, though the running machine keeps it
-	 * until the next reboot.)
+	 * saves.
 	 */
-	async insertDiskFile(file: File): Promise<void> {
+	async attachDiskFile(file: File): Promise<void> {
 		const contents = new Uint8Array(await file.arrayBuffer());
 		let disk: AtrImage;
 		try {
@@ -521,21 +547,21 @@ export class EmulatorHost {
 			return;
 		}
 
-		this.#attachment = { disk };
-		this.imageName.value = file.name;
+		this.#drives[0] = { disk, name: file.name };
 		this.#emulator.machine.insertDisk(disk);
 		this.sidebar.value = null; // get out of the way
+		this.#refreshAttachments();
 	}
 
-	/** Remove the disk from D1: of the running machine (live, no reboot). */
-	removeDisk(): void {
-		if (!this.#attachment || !("disk" in this.#attachment)) {
-			this.alert.value = "No disk in D1: to remove.";
+	/** Detach the disk from D1: of the running machine (live, no reboot). */
+	detachDisk(): void {
+		if (!this.#drives[0]) {
+			this.alert.value = "No disk in D1: to detach.";
 			return;
 		}
-		this.#attachment = null;
-		this.imageName.value = null;
+		this.#drives[0] = null;
 		this.#emulator.machine.ejectDisk();
+		this.#refreshAttachments();
 	}
 
 	/**

--- a/packages/a8/src/atr.test.ts
+++ b/packages/a8/src/atr.test.ts
@@ -50,3 +50,47 @@ test("invalid images are rejected", () => {
 	badSectorSize[4] = 64;
 	expect(() => new AtrImage(badSectorSize)).toThrow("sector size");
 });
+
+test("writeSector round-trips and rejects out-of-range sectors", () => {
+	const atr = new AtrImage(makeAtr(128, 8));
+
+	expect(atr.writeSector(4, new Uint8Array(128).fill(0xab))).toBe(true);
+	expect(atr.readSector(4)![0]).toBe(0xab);
+	expect(atr.readSector(4)![127]).toBe(0xab);
+	// A neighbor keeps its fixture value.
+	expect(atr.readSector(5)![0]).toBe(5);
+
+	expect(atr.writeSector(0, new Uint8Array(128))).toBe(false);
+	expect(atr.writeSector(9, new Uint8Array(128))).toBe(false);
+});
+
+test("writeSector honors the double-density boot-sector layout", () => {
+	const atr = new AtrImage(makeAtr(256, 8));
+
+	// Boot sectors transfer 128 bytes even on DD.
+	expect(atr.writeSector(2, new Uint8Array(128).fill(0x11))).toBe(true);
+	expect(atr.readSector(2)).toHaveLength(128);
+	expect(atr.readSector(2)![127]).toBe(0x11);
+
+	// Data sectors are full 256-byte slots and don't bleed into the boot area.
+	expect(atr.writeSector(4, new Uint8Array(256).fill(0x22))).toBe(true);
+	expect(atr.readSector(4)![255]).toBe(0x22);
+	expect(atr.readSector(3)![0]).toBe(3);
+});
+
+test("toBytes reflects writes and preserves the header", () => {
+	const atr = new AtrImage(makeAtr(128, 4));
+	atr.writeSector(1, new Uint8Array(128).fill(0x5a));
+
+	const bytes = atr.toBytes();
+	expect(bytes[0]).toBe(0x96); // header magic intact
+	expect(bytes[1]).toBe(0x02);
+	expect(bytes[16]).toBe(0x5a); // first data byte = sector 1, byte 0
+});
+
+test("write protection defaults off and is settable", () => {
+	expect(new AtrImage(makeAtr(128, 4)).writeProtected).toBe(false);
+	expect(
+		new AtrImage(makeAtr(128, 4), { writeProtected: true }).writeProtected,
+	).toBe(true);
+});

--- a/packages/a8/src/atr.ts
+++ b/packages/a8/src/atr.ts
@@ -1,5 +1,5 @@
 /**
- * An ATR disk image, read-only for now.
+ * An ATR disk image.
  *
  * Layout: a 16-byte header ($96 $02 magic, image size in 16-byte paragraphs,
  * sector size) followed by raw sector data. On double-density (256-byte
@@ -7,16 +7,30 @@
  * always transfers as 128 bytes — are usually stored as 128 bytes, but some
  * tools store them as full 256-byte slots; both layouts are detected by the
  * data length's remainder.
+ *
+ * Sectors are mutable ({@link writeSector}); writes land in the same backing
+ * buffer {@link toBytes} hands back, so a modified image round-trips to a
+ * fresh `.atr` byte-for-byte (header included). `writeProtected` models the
+ * disk's write-protect notch — a property of the medium; a protected image
+ * rejects writes. (For a synthetic disk this is policy, not a real notch —
+ * see {@link ./xex-boot.ts}.)
  */
 export class AtrImage {
 	readonly sectorSize: 128 | 256;
 	readonly sectorCount: number;
+	readonly writeProtected: boolean;
 
+	// The full image (header + data); #data views the data region of the same
+	// buffer, so writes through #data are visible in #raw and thus toBytes().
+	readonly #raw: Uint8Array;
 	readonly #data: Uint8Array;
 	// Whether sectors 1-3 occupy 128-byte slots on a double-density image.
 	readonly #boot128: boolean;
 
-	constructor(contents: Uint8Array) {
+	constructor(
+		contents: Uint8Array,
+		options: { writeProtected?: boolean } = {},
+	) {
 		if (contents.length < 16 || contents[0] !== 0x96 || contents[1] !== 0x02) {
 			throw new Error("Not an ATR image");
 		}
@@ -27,6 +41,8 @@ export class AtrImage {
 		}
 
 		this.sectorSize = sectorSize;
+		this.writeProtected = options.writeProtected ?? false;
+		this.#raw = contents;
 		this.#data = contents.subarray(16);
 
 		const length = this.#data.length;
@@ -45,27 +61,57 @@ export class AtrImage {
 		}
 	}
 
-	/**
-	 * The contents of a sector (1-based), or `null` when out of range. The
-	 * boot sectors (1-3) are 128 bytes even on double-density images, like
-	 * the bytes a real drive would transfer.
-	 */
-	readSector(sector: number): Uint8Array | null {
+	// The data-region offset and transfer length of a 1-based sector, or null
+	// when out of range. Boot sectors (1-3) always transfer 128 bytes; on a
+	// double-density image they occupy 128- or 256-byte slots per #boot128.
+	#locate(sector: number): { offset: number; length: number } | null {
 		if (sector < 1 || sector > this.sectorCount) return null;
 
 		if (this.sectorSize === 128) {
-			const offset = (sector - 1) * 128;
-			return this.#data.subarray(offset, offset + 128);
+			return { offset: (sector - 1) * 128, length: 128 };
 		}
 
 		if (sector <= 3) {
-			const offset = (sector - 1) * (this.#boot128 ? 128 : 256);
-			return this.#data.subarray(offset, offset + 128);
+			return {
+				offset: (sector - 1) * (this.#boot128 ? 128 : 256),
+				length: 128,
+			};
 		}
 
 		const offset = this.#boot128
 			? 384 + (sector - 4) * 256
 			: (sector - 1) * 256;
-		return this.#data.subarray(offset, offset + 256);
+		return { offset, length: 256 };
+	}
+
+	/**
+	 * The contents of a sector (1-based), or `null` when out of range. The
+	 * boot sectors (1-3) are 128 bytes even on double-density images, like
+	 * the bytes a real drive would transfer. The result is a live view into
+	 * the backing buffer.
+	 */
+	readSector(sector: number): Uint8Array | null {
+		const loc = this.#locate(sector);
+		if (!loc) return null;
+		return this.#data.subarray(loc.offset, loc.offset + loc.length);
+	}
+
+	/**
+	 * Overwrite a sector (1-based) with `data`, copying up to the sector's
+	 * transfer length (extra bytes are ignored, short writes leave the tail
+	 * untouched). Returns `false` when the sector is out of range. The caller
+	 * is responsible for the write-protect check; this writes regardless.
+	 */
+	writeSector(sector: number, data: ArrayLike<number>): boolean {
+		const loc = this.#locate(sector);
+		if (!loc) return false;
+		const n = Math.min(loc.length, data.length);
+		for (let i = 0; i < n; i++) this.#data[loc.offset + i] = data[i]! & 0xff;
+		return true;
+	}
+
+	/** The full image bytes (header + data), reflecting any writes. */
+	toBytes(): Uint8Array {
+		return this.#raw;
 	}
 }

--- a/packages/a8/src/machine.ts
+++ b/packages/a8/src/machine.ts
@@ -426,6 +426,14 @@ export class Atari implements Memory {
 	}
 
 	/**
+	 * Eject the D1: disk. Safe to call on a running machine: SIO requests then
+	 * time out and the OS falls through to its other boot sources.
+	 */
+	ejectDisk(): void {
+		this.#disk = undefined;
+	}
+
+	/**
 	 * Press joystick directions. `port` is 0-1 on the XL (two jacks) and 0-3
 	 * on the 800, whose ports 2/3 live on PIA port B; presses on ports the
 	 * machine doesn't have are ignored. `mask` is a set of direction bits:

--- a/packages/a8/src/sio.test.ts
+++ b/packages/a8/src/sio.test.ts
@@ -83,28 +83,67 @@ test("an empty drive and a non-disk device time out", () => {
 	expect(cpu.Y).toBe(0x8a);
 });
 
-test("out-of-range sectors and writes report a device error", () => {
+test("out-of-range reads and writes report a device error", () => {
 	const { machine, cpu, handler } = setup(new AtrImage(makeAtr(128, 4)));
 
 	setDcb(machine, { command: 0x52, buffer: 0x2000, byteCount: 128, aux: 5 });
 	handler(SIOV);
 	expect(cpu.Y).toBe(0x90);
 
-	setDcb(machine, { command: 0x57, buffer: 0x2000, byteCount: 128, aux: 1 });
+	setDcb(machine, { command: 0x57, buffer: 0x2000, byteCount: 128, aux: 5 });
 	handler(SIOV);
 	expect(cpu.Y).toBe(0x90);
 });
 
-test("the status command reports write protection and density", () => {
+test("write sector stores bytes that read back", () => {
+	const disk = new AtrImage(makeAtr(128, 4));
+	const { machine, cpu, handler } = setup(disk);
+
+	for (let i = 0; i < 128; i++) {
+		machine.write(0x2000 + i, (i + 1) & 0xff, ReadOptions.NONE);
+	}
+	setDcb(machine, { command: 0x57, buffer: 0x2000, byteCount: 128, aux: 2 });
+
+	expect(handler(SIOV)).toBe(0x60); // RTS
+	expect(cpu.Y).toBe(0x01);
+
+	const stored = disk.readSector(2)!;
+	expect(stored[0]).toBe(1);
+	expect(stored[127]).toBe(128 & 0xff);
+	// A neighboring sector is untouched.
+	expect(disk.readSector(3)![0]).toBe(3);
+});
+
+test("writes to a write-protected disk report a device error", () => {
+	const disk = new AtrImage(makeAtr(128, 4), { writeProtected: true });
+	const { machine, cpu, handler } = setup(disk);
+
+	machine.write(0x2000, 0xff, ReadOptions.NONE);
+	setDcb(machine, { command: 0x57, buffer: 0x2000, byteCount: 128, aux: 2 });
+	handler(SIOV);
+
+	expect(cpu.Y).toBe(0x90);
+	expect(disk.readSector(2)![0]).toBe(2); // unchanged
+});
+
+test("the status command reports density and write protection", () => {
+	// A writable single-density disk: neither bit.
 	const single = setup(new AtrImage(makeAtr(128, 4)));
 	setDcb(single.machine, { command: 0x53, buffer: 0x02ea, byteCount: 4 });
 	single.handler(SIOV);
-	expect(single.machine.read(0x02ea, ReadOptions.NONE)).toBe(0x08);
+	expect(single.machine.read(0x02ea, ReadOptions.NONE)).toBe(0x00);
 
+	// Double density sets the density bit.
 	const double = setup(new AtrImage(makeAtr(256, 4)));
 	setDcb(double.machine, { command: 0x53, buffer: 0x02ea, byteCount: 4 });
 	double.handler(SIOV);
-	expect(double.machine.read(0x02ea, ReadOptions.NONE)).toBe(0x28);
+	expect(double.machine.read(0x02ea, ReadOptions.NONE)).toBe(0x20);
+
+	// A protected disk sets the write-protect bit.
+	const locked = setup(new AtrImage(makeAtr(128, 4), { writeProtected: true }));
+	setDcb(locked.machine, { command: 0x53, buffer: 0x02ea, byteCount: 4 });
+	locked.handler(SIOV);
+	expect(locked.machine.read(0x02ea, ReadOptions.NONE)).toBe(0x08);
 });
 
 test("the trap fires on a real JSR through SIOV", () => {

--- a/packages/a8/src/sio.ts
+++ b/packages/a8/src/sio.ts
@@ -42,9 +42,15 @@ export interface SioHandlerOptions {
  * through SIOV/DSKINV). Custom fast loaders that drive POKEY's serial port
  * directly will need real serial emulation instead.
  *
- * Read-only for now: write commands report a device error, and the status
- * command flags the disk as write-protected. The handler is idempotent by
- * design — a WSYNC stall can repeat the trapped fetch.
+ * The trap is a thin translator: each SIO command maps to a method on the
+ * {@link AtrImage} medium (read/write a sector, report write-protect and
+ * density). Disk behavior lives on the image, not here — so a future real
+ * drive (a 1050/Happy with its own 6507 running the protocol on the wire)
+ * could slot in behind `getDisk` without rewriting this trap; it'd be a
+ * separate subsystem, not a refactor of it.
+ *
+ * The handler is idempotent by design — a WSYNC stall can repeat the trapped
+ * fetch (re-running a write just replays the same bytes to the same sector).
  */
 export function createSioHandler(
 	options: SioHandlerOptions,
@@ -95,19 +101,32 @@ export function createSioHandler(
 			}
 
 			case 0x53:
-				// Drive status: write-protected (read-only for now), plus the
-				// density bit; FDC status inverted (no error), format timeout.
+				// Drive status: write-protect bit when the medium is protected,
+				// plus the density bit; FDC status inverted (no error), format
+				// timeout.
 				return transfer([
-					0x08 | (disk.sectorSize === 256 ? 0x20 : 0),
+					(disk.writeProtected ? 0x08 : 0) |
+						(disk.sectorSize === 256 ? 0x20 : 0),
 					0xff,
 					0xe0,
 					0x00,
 				]);
 
 			case 0x50:
-			case 0x57:
-				// Write/put sector: read-only for now.
-				return complete(STATUS_DEVICE_ERROR);
+			case 0x57: {
+				// Put (no verify) / write (with verify) a sector. With no
+				// physical media there's nothing to verify, so both just store
+				// the bytes the OS staged in the SIO buffer.
+				if (disk.writeProtected) return complete(STATUS_DEVICE_ERROR);
+				const sector = peek(DAUX1) | (peek(DAUX2) << 8);
+				const data = new Uint8Array(byteCount);
+				for (let i = 0; i < byteCount; i++) {
+					data[i] = peek((buffer + i) & 0xffff);
+				}
+				return disk.writeSector(sector, data)
+					? complete(STATUS_OK)
+					: complete(STATUS_DEVICE_ERROR);
+			}
 
 			default:
 				return complete(STATUS_NAK);

--- a/packages/a8/src/xex-boot.ts
+++ b/packages/a8/src/xex-boot.ts
@@ -38,5 +38,7 @@ export function buildBootDisk(xex: Uint8Array): AtrImage {
 	// The executable itself, from sector 4 on
 	image.set(xex, 16 + 384);
 
-	return new AtrImage(image);
+	// Synthetic boot disk: write-protected so a program can't scribble on its
+	// own loader (and so it's never offered for download as a "disk").
+	return new AtrImage(image, { writeProtected: true });
 }


### PR DESCRIPTION
First pass at writable disks, plus the attach/detach/download commands the palette exists to drive.

## Core (`@sfotty-pie/a8`)
- `AtrImage` is now mutable and serializable: `writeSector`, `toBytes`, a `writeProtected` flag, and a shared `#locate` so read/write offset math can't drift. The full image buffer (header included) is retained, so a modified disk round-trips byte-for-byte.
- The built-in SIO drive implements write (`0x57`) and put (`0x50`), honors write-protect, and reports the write-protect bit in its status only when actually protected. XEX boot disks are write-protected (immutable, and excluded from download).
- `Atari.ejectDisk()` for live ejection.

## Web app (`apps/a8-web`)
- Palette commands: **Attach/Detach disk (D1:)** (live, no reboot), **Download D1:**, **Attach/Detach cartridge** (cold boot, leaves other media in place).
- The single attachment slot is split into an independent cartridge slot + a disk-drive array (D1: now, shaped for D2: later), so a cartridge and a disk coexist.
- Bottom bar shows all attachments: `Cart: …` (a cartridge ROM name, or BASIC only on the 400/800 where it occupies the slot) and `D1: …`.
- `Detach cartridge`: removes an explicit cart, or on the 400/800 disables an enabled BASIC (which fills the slot), else reports nothing to remove.

## Scope / deferred
- Writes are in-memory; Download is how you keep them (no persistence layer yet).
- No shadow-mounting — a program that needs a real disk attaches one after boot.
- Drive power state ("disk loaded but drive off") and D2: are designed-for but not built.

## Testing
Verified by hand (DOS 2.0 Save Binary round-trip on D1:) and the extended `a8` unit suite (write round-trip, DD boot-sector layout, write-protect, status bits). `pnpm test` green in both packages.