### PR TITLE
feat(a8-web): emit hashed assets to /_app/assets and add a 404 page

### DIFF
--- a/apps/a8-web/public/404/index.html
+++ b/apps/a8-web/public/404/index.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>404 — Not Found</title>
+		<style>
+			html,
+			body {
+				margin: 0;
+				height: 100%;
+				background: #000;
+				color: #ddd;
+				font:
+					16px/1.5 system-ui,
+					sans-serif;
+			}
+			body {
+				display: flex;
+				flex-direction: column;
+				align-items: center;
+				justify-content: center;
+				gap: 0.5rem;
+				text-align: center;
+				padding: 1rem;
+			}
+			h1 {
+				margin: 0;
+				font-size: 4rem;
+				font-weight: 700;
+			}
+			a {
+				color: #6cf;
+			}
+		</style>
+	</head>
+	<body>
+		<h1>404</h1>
+		<p>That page doesn't exist.</p>
+		<p><a href="/">Back to A8 web</a></p>
+	</body>
+</html>

--- a/apps/a8-web/src/messages.ts
+++ b/apps/a8-web/src/messages.ts
@@ -55,6 +55,7 @@ export const messages = {
 		firmwareNotice:
 			"Bundled firmware (AltirraOS, Altirra BASIC, Atari++) is used under its own license.",
 		thirdPartyLicenses: "Third-party licenses",
+		build: "Build",
 		titleMenu: "Sfotty Pie A8 Web",
 		titlePalette: "Commands",
 	},

--- a/apps/a8-web/src/sidebar.tsx
+++ b/apps/a8-web/src/sidebar.tsx
@@ -258,6 +258,9 @@ function MenuView({
 					</a>
 					.
 				</p>
+				<p class="mt-1 font-mono text-xs text-neutral-400">
+					{messages.sidebar.build} {import.meta.env.GIT_HASH}
+				</p>
 			</section>
 		</div>
 	);

--- a/apps/a8-web/src/vite-env.d.ts
+++ b/apps/a8-web/src/vite-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+	/** Short commit hash of the build (`-dirty` if the tree had changes). */
+	readonly GIT_HASH: string;
+}
+
+interface ImportMeta {
+	readonly env: ImportMetaEnv;
+}

--- a/apps/a8-web/vite.config.ts
+++ b/apps/a8-web/vite.config.ts
@@ -1,10 +1,26 @@
+import { execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import preact from "@preact/preset-vite";
 import basicSsl from "@vitejs/plugin-basic-ssl";
 import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vite";
 
+// The commit the build was made from, surfaced in the UI to identify manual
+// deployments. Marked `-dirty` when the tree has uncommitted changes, and
+// `unknown` outside a git checkout.
+function gitHash(): string {
+	try {
+		const hash = execSync("git rev-parse --short HEAD").toString().trim();
+		const dirty = execSync("git status --porcelain").toString().trim() !== "";
+		return dirty ? `${hash}-dirty` : hash;
+	} catch {
+		return "unknown";
+	}
+}
+
 export default defineConfig({
+	// Build-time constant: replaces `import.meta.env.GIT_HASH` in the source.
+	define: { "import.meta.env.GIT_HASH": JSON.stringify(gitHash()) },
 	// basicSsl serves dev over HTTPS so the page is a secure context on a LAN
 	// IP — required for AudioWorklet (and other secure-only APIs) to exist when
 	// testing on a real device. Expect a one-time "untrusted certificate"

--- a/apps/a8-web/vite.config.ts
+++ b/apps/a8-web/vite.config.ts
@@ -36,6 +36,10 @@ export default defineConfig({
 	// (keyboard-lab.html, served at /keyboard-lab.html) — shipped so its
 	// capturability probes can be run on borrowed/remote machines.
 	build: {
+		// Emit hashed, content-addressed assets under /_app/assets so the
+		// deploy's Nginx can serve them with a long-lived immutable cache
+		// (everything here is fingerprinted, so it's safe to cache forever).
+		assetsDir: "_app/assets",
 		rollupOptions: {
 			input: {
 				main: fileURLToPath(new URL("./index.html", import.meta.url)),


### PR DESCRIPTION
Two a8-web changes, both bundled here.

### Show the build's git hash in the About section (`7f5a802`)
Surfaces the commit a build was made from in the UI, so manual deployments are identifiable. Marked `-dirty` when the tree has uncommitted changes, `unknown` outside a git checkout.

### Align asset output with the deploy's Nginx caching (`db3a884`)
- Set Vite `build.assetsDir` to `_app/assets` so fingerprinted, content-addressed assets land where the server applies its long-lived `immutable` cache header (they previously went to `/assets`, which the cache rule never matched).
- Add a simple self-contained `public/404/index.html` so the server's `error_page 404` resolves to a real page.

Nginx config is updated separately on the server (not in this repo).