### PR TITLE
feat(a8-web): add a full-screen toggle (command + double-click)

### DIFF
--- a/apps/a8-web/src/app.tsx
+++ b/apps/a8-web/src/app.tsx
@@ -64,8 +64,12 @@ export function App({ host }: { host: EmulatorHost }) {
 			<div class="flex min-h-0 flex-1 flex-col overflow-hidden">
 				<TopBar host={host} />
 
-				{/* The screen: canvas centered, sized by the host, letterboxed. */}
-				<div class="relative flex-1 overflow-hidden bg-black">
+				{/* The screen: canvas centered, sized by the host, letterboxed.
+				    Double-click anywhere on it toggles full screen. */}
+				<div
+					class="relative flex-1 overflow-hidden bg-black"
+					onDblClick={() => host.dispatch("TOGGLE_FULLSCREEN")}
+				>
 					<canvas
 						ref={canvasRef}
 						width={FRAME_BUFFER_WIDTH}

--- a/apps/a8-web/src/commands.ts
+++ b/apps/a8-web/src/commands.ts
@@ -66,6 +66,14 @@ export const commands = {
 		run: ({ host }) => host.togglePanel("menu"),
 	},
 
+	// Full-screen the whole app (chrome included), so the on-screen controls
+	// stay reachable. A no-op-safe toggle; also bound to a double-click on the
+	// screen.
+	TOGGLE_FULLSCREEN: {
+		label: "TOGGLE_FULLSCREEN",
+		run: ({ host }) => host.toggleFullscreen(),
+	},
+
 	// Boot a file as a fresh machine image (opens the file picker).
 	BOOT_IMAGE: { label: "BOOT_IMAGE", run: ({ host }) => host.pickBootImage() },
 

--- a/apps/a8-web/src/host.ts
+++ b/apps/a8-web/src/host.ts
@@ -458,6 +458,27 @@ export class EmulatorHost {
 		else this.showPanel(panel);
 	}
 
+	/**
+	 * Enter or leave full screen. Targets the whole document so the toolbar and
+	 * the on-screen OSD controls stay in view (the canvas refits via its
+	 * ResizeObserver). Where the Fullscreen API is unavailable — notably iPhone
+	 * Safari, which only fullscreens video — say so rather than silently fail.
+	 */
+	toggleFullscreen(): void {
+		if (document.fullscreenElement) {
+			void document.exitFullscreen();
+			return;
+		}
+		const root = document.documentElement;
+		if (!root.requestFullscreen) {
+			this.toast(messages.errors.fullscreenUnavailable, "warning");
+			return;
+		}
+		void root.requestFullscreen().catch(() => {
+			this.toast(messages.errors.fullscreenUnavailable, "warning");
+		});
+	}
+
 	// Machine configuration. The menu's form stages changes (below) and applies
 	// them with a single reboot; the palette's config commands apply one change
 	// and reboot immediately (apply*, below that).

--- a/apps/a8-web/src/messages.ts
+++ b/apps/a8-web/src/messages.ts
@@ -94,6 +94,7 @@ export const messages = {
 		noDiskToDetach: "No disk in D1: to detach.",
 		notACartridge: "not a cartridge image",
 		noCartridge: "No cartridge to detach.",
+		fullscreenUnavailable: "Full screen isn't available in this browser.",
 		noCompatibleOs: (model: string, tv: string) =>
 			`No compatible OS ROM in the library for ${model} (${tv}).`,
 	},
@@ -137,6 +138,7 @@ export const labels = {
 	AUDIO_UNMUTE: "Unmute audio",
 	AUDIO_TOGGLE: "Toggle audio (enable, then mute/unmute)",
 	MENU_TOGGLE: "Toggle the menu",
+	TOGGLE_FULLSCREEN: "Toggle full screen",
 	BOOT_IMAGE: "Boot a disk, cartridge, or executable…",
 	ATTACH_D1: "Attach a disk to D1:…",
 	DETACH_D1: "Detach the disk from D1:",


### PR DESCRIPTION
Adds a single full-screen toggle to a8-web.

- New `TOGGLE_FULLSCREEN` command ("Toggle full screen") in the command palette — one toggle, no separate on/off commands.
- Double-clicking anywhere on the emulator view (canvas or letterbox) toggles it too.
- No keyboard binding.

Fullscreens the whole document, not just the canvas, so the toolbar and on-screen OSD controls stay reachable; the canvas refits via its existing ResizeObserver. Where the Fullscreen API is unavailable (notably iPhone Safari, which only fullscreens video), it shows a warning toast instead of failing silently.