### PR TITLE
feat(a8-web): replace UI glyphs with an SVG icon sprite

### DIFF
--- a/apps/a8-web/public/legal/THIRD-PARTY-LICENSES.md
+++ b/apps/a8-web/public/legal/THIRD-PARTY-LICENSES.md
@@ -1,6 +1,6 @@
 # Third-party licenses
 
-Sfotty Pie itself is MIT-licensed. The replacement firmware ROMs bundled with this web app keep their own licenses, reproduced below. (These are independent works the emulator loads as data — bundling them does not relicense Sfotty Pie's own code.)
+Sfotty Pie itself is MIT-licensed. The replacement firmware ROMs and the UI icons bundled with this web app keep their own licenses, reproduced below. (These are independent works — bundling them does not relicense Sfotty Pie's own code.)
 
 Sfotty Pie is an independent project and is not affiliated with or endorsed by Atari, the Altirra project (Avery Lee), or the Atari++ project (Thomas Richter).
 
@@ -34,3 +34,17 @@ Per the TPL, the corresponding source code is made available here:
 - Basic++ source: [basic++.tar.gz](atari++/basic++.tar.gz)
 
 Bundled items: `Atari++ OS`, `Atari++ BASIC`. The ROMs here are distributed unmodified; any modifications would be subject to the TPL.
+
+---
+
+## Lucide icons
+
+The UI icons are from [Lucide](https://lucide.dev), embedded in the app's icon sprite. Lucide is offered under the **ISC license**:
+
+> ISC License
+>
+> Copyright (c) for portions of Lucide are held by Cole Bemis 2013-2022 as part of Feather (MIT). All other copyright (c) for Lucide are held by Lucide Contributors 2022.
+>
+> Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
+>
+> THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/apps/a8-web/src/icon.tsx
+++ b/apps/a8-web/src/icon.tsx
@@ -1,0 +1,53 @@
+import type { ComponentProps } from "preact";
+import iconsUrl from "./icons.svg";
+
+/**
+ * Every icon in the sprite (src/icons.svg), keyed by its `<symbol>` id. The
+ * single source of truth for icon names — keep it in sync with the sprite (a
+ * mismatch renders an empty icon, visible immediately in the UI).
+ */
+export const ICON_NAMES = [
+	"menu",
+	"close",
+	"joystick",
+	"keyboard",
+	"chevron-down",
+	"swap",
+	"play",
+	"pause",
+	"zap",
+	"volume",
+	"volume-2",
+	"volume-x",
+	"volume-off",
+] as const;
+
+export type IconName = (typeof ICON_NAMES)[number];
+
+/**
+ * A single-color icon, pulled from the SVG sprite by name. Sized to the
+ * surrounding font (1em) and inheriting `currentColor`, so it drops in where a
+ * text glyph used to sit; pass `class`/`style`/handlers (anything an `<svg>`
+ * takes) to override. The sprite's icons are stroked (Lucide), so the stroke
+ * presentation is set here and inherited by the referenced symbol.
+ */
+export function Icon({
+	name,
+	...props
+}: { name: IconName } & ComponentProps<"svg">) {
+	return (
+		<svg
+			width="1em"
+			height="1em"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			aria-hidden="true"
+			{...props}
+		>
+			<use href={`${iconsUrl}#${name}`} />
+		</svg>
+	);
+}

--- a/apps/a8-web/src/icons.svg
+++ b/apps/a8-web/src/icons.svg
@@ -1,0 +1,76 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+	<!--
+		Icon sprite: one <symbol> per icon, referenced by id from the Icon
+		component (src/icon.tsx) via <use href="…#id">. Icons are from Lucide
+		(https://lucide.dev), ISC-licensed. The stroke styling (fill/stroke/
+		width/linecaps) is set on the <svg> wrapper in icon.tsx and inherited
+		across the <use> boundary, so the symbols carry geometry only.
+
+		Symbol ids must stay in sync with ICON_NAMES in icon.tsx.
+	-->
+	<symbol id="menu" viewBox="0 0 24 24">
+		<path d="M4 5h16" />
+		<path d="M4 12h16" />
+		<path d="M4 19h16" />
+	</symbol>
+	<symbol id="close" viewBox="0 0 24 24">
+		<path d="M18 6 6 18" />
+		<path d="m6 6 12 12" />
+	</symbol>
+	<symbol id="joystick" viewBox="0 0 24 24">
+		<path d="M21 17a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v2a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-2Z" />
+		<path d="M6 15v-2" />
+		<path d="M12 15V9" />
+		<circle cx="12" cy="6" r="3" />
+	</symbol>
+	<symbol id="keyboard" viewBox="0 0 24 24">
+		<path d="M10 8h.01" />
+		<path d="M12 12h.01" />
+		<path d="M14 8h.01" />
+		<path d="M16 12h.01" />
+		<path d="M18 8h.01" />
+		<path d="M6 8h.01" />
+		<path d="M7 16h10" />
+		<path d="M8 12h.01" />
+		<rect width="20" height="16" x="2" y="4" rx="2" />
+	</symbol>
+	<symbol id="chevron-down" viewBox="0 0 24 24">
+		<path d="m6 9 6 6 6-6" />
+	</symbol>
+	<symbol id="swap" viewBox="0 0 24 24">
+		<path d="M8 3 4 7l4 4" />
+		<path d="M4 7h16" />
+		<path d="m16 21 4-4-4-4" />
+		<path d="M20 17H4" />
+	</symbol>
+	<symbol id="play" viewBox="0 0 24 24">
+		<path d="M5 5a2 2 0 0 1 3.008-1.728l11.997 6.998a2 2 0 0 1 .003 3.458l-12 7A2 2 0 0 1 5 19z" />
+	</symbol>
+	<symbol id="pause" viewBox="0 0 24 24">
+		<rect x="14" y="3" width="5" height="18" rx="1" />
+		<rect x="5" y="3" width="5" height="18" rx="1" />
+	</symbol>
+	<symbol id="zap" viewBox="0 0 24 24">
+		<path d="M4 14a1 1 0 0 1-.78-1.63l9.9-10.2a.5.5 0 0 1 .86.46l-1.92 6.02A1 1 0 0 0 13 10h7a1 1 0 0 1 .78 1.63l-9.9 10.2a.5.5 0 0 1-.86-.46l1.92-6.02A1 1 0 0 0 11 14z" />
+	</symbol>
+	<symbol id="volume" viewBox="0 0 24 24">
+		<path d="M11 4.702a.705.705 0 0 0-1.203-.498L6.413 7.587A1.4 1.4 0 0 1 5.416 8H3a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h2.416a1.4 1.4 0 0 1 .997.413l3.383 3.384A.705.705 0 0 0 11 19.298z" />
+	</symbol>
+	<symbol id="volume-2" viewBox="0 0 24 24">
+		<path d="M11 4.702a.705.705 0 0 0-1.203-.498L6.413 7.587A1.4 1.4 0 0 1 5.416 8H3a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h2.416a1.4 1.4 0 0 1 .997.413l3.383 3.384A.705.705 0 0 0 11 19.298z" />
+		<path d="M16 9a5 5 0 0 1 0 6" />
+		<path d="M19.364 18.364a9 9 0 0 0 0-12.728" />
+	</symbol>
+	<symbol id="volume-x" viewBox="0 0 24 24">
+		<path d="M11 4.702a.705.705 0 0 0-1.203-.498L6.413 7.587A1.4 1.4 0 0 1 5.416 8H3a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h2.416a1.4 1.4 0 0 1 .997.413l3.383 3.384A.705.705 0 0 0 11 19.298z" />
+		<line x1="22" x2="16" y1="9" y2="15" />
+		<line x1="16" x2="22" y1="9" y2="15" />
+	</symbol>
+	<symbol id="volume-off" viewBox="0 0 24 24">
+		<path d="M16 9a5 5 0 0 1 .95 2.293" />
+		<path d="M19.364 5.636a9 9 0 0 1 1.889 9.96" />
+		<path d="m2 2 20 20" />
+		<path d="m7 7-.587.587A1.4 1.4 0 0 1 5.416 8H3a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h2.416a1.4 1.4 0 0 1 .997.413l3.383 3.384A.705.705 0 0 0 11 19.298V11" />
+		<path d="M9.828 4.172A.686.686 0 0 1 11 4.657v.686" />
+	</symbol>
+</svg>

--- a/apps/a8-web/src/osd.tsx
+++ b/apps/a8-web/src/osd.tsx
@@ -2,6 +2,7 @@ import type { TargetedTouchEvent } from "preact";
 import { useEffect, useState } from "preact/hooks";
 import type { Command } from "./commands.ts";
 import type { EmulatorHost } from "./host.ts";
+import { Icon, type IconName } from "./icon.tsx";
 import { messages } from "./messages.ts";
 import { KeyboardView } from "./osd-keyboard.tsx";
 
@@ -197,7 +198,7 @@ function ResetButton({ host }: { host: EmulatorHost }) {
 	);
 }
 
-/** The 🕹 / ⌨ segmented control that swaps the OSD body between views. */
+/** The joystick / keyboard segmented control that swaps the OSD body. */
 function ViewToggle({
 	view,
 	onChange,
@@ -205,31 +206,33 @@ function ViewToggle({
 	view: OsdView;
 	onChange: (view: OsdView) => void;
 }) {
-	const tab = (v: OsdView, label: string, aria: string) => (
+	const tab = (v: OsdView, icon: IconName, aria: string) => (
 		<button
 			type="button"
 			aria-label={aria}
+			title={aria}
 			aria-pressed={view === v}
 			class={`rounded px-3 py-1 text-lg select-none ${
 				view === v ? "bg-neutral-500 text-white" : "text-neutral-400"
 			}`}
 			onClick={() => onChange(v)}
 		>
-			{label}
+			<Icon name={icon} />
 		</button>
 	);
 	return (
 		<div class="flex gap-1 rounded bg-neutral-800 p-0.5">
-			{tab("stick", "🕹", messages.osd.joystickControls)}
-			{tab("keyboard", "⌨", messages.osd.keyboard)}
-			{tab("off", "▾", messages.osd.hideControls)}
+			{tab("stick", "joystick", messages.osd.joystickControls)}
+			{tab("keyboard", "keyboard", messages.osd.keyboard)}
+			{tab("off", "chevron-down", messages.osd.hideControls)}
 		</div>
 	);
 }
 
 /**
  * The on-screen controls for touch devices. A persistent top bar (Power + a
- * 🕹/⌨ view toggle) sits over a body that swaps between the joystick view (a
+ * joystick/keyboard view toggle) sits over a body that swaps between the
+ * joystick view (a
  * row of console keys over a fire button and analog stick, with a left-hander
  * swap) and the on-screen keyboard. Shown only when the primary pointer is
  * coarse and the menu is closed (the menu becomes a top bar on mobile and
@@ -300,6 +303,7 @@ export function Osd({ host }: { host: EmulatorHost }) {
 						<button
 							type="button"
 							aria-label={messages.osd.swapSides}
+							title={messages.osd.swapSides}
 							class="rounded bg-neutral-700/70 px-3 py-2 text-lg text-white active:bg-neutral-500"
 							onClick={() => {
 								const next = !lefty;
@@ -307,7 +311,7 @@ export function Osd({ host }: { host: EmulatorHost }) {
 								setLefty(next);
 							}}
 						>
-							⇄
+							<Icon name="swap" />
 						</button>
 						{lefty ? fire : stick}
 					</div>

--- a/apps/a8-web/src/sidebar.tsx
+++ b/apps/a8-web/src/sidebar.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "preact/hooks";
 import type { EmulatorHost } from "./host.ts";
+import { Icon } from "./icon.tsx";
 import { builtinLibrary } from "./library.ts";
 import { messages } from "./messages.ts";
 import { PaletteView } from "./palette.tsx";
@@ -328,9 +329,10 @@ export function Sidebar({ host }: { host: EmulatorHost }) {
 					type="button"
 					class="px-1 text-neutral-500 hover:text-neutral-900"
 					aria-label={messages.sidebar.close}
+					title={messages.sidebar.close}
 					onClick={() => host.closePanel()}
 				>
-					✕
+					<Icon name="close" />
 				</button>
 			</div>
 

--- a/apps/a8-web/src/toasts.tsx
+++ b/apps/a8-web/src/toasts.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "preact/hooks";
 import type { EmulatorHost, Toast } from "./host.ts";
+import { Icon } from "./icon.tsx";
 import { messages } from "./messages.ts";
 
 // Auto-dismiss timings: warnings linger longer than plain info.
@@ -68,9 +69,10 @@ function ErrorToast({
 				type="button"
 				class="shrink-0 px-1 hover:text-red-200"
 				aria-label={messages.toasts.dismiss}
+				title={messages.toasts.dismiss}
 				onClick={onDismiss}
 			>
-				✕
+				<Icon name="close" />
 			</button>
 		</div>
 	);

--- a/apps/a8-web/src/top-bar.tsx
+++ b/apps/a8-web/src/top-bar.tsx
@@ -1,5 +1,16 @@
-import type { EmulatorHost } from "./host.ts";
+import type { AudioState, EmulatorHost } from "./host.ts";
+import { Icon, type IconName } from "./icon.tsx";
 import { messages } from "./messages.ts";
+
+// The audio indicator's icon per state: full waves when on, an X when muted,
+// a plain speaker awaiting the first gesture (suspended), and a slashed
+// speaker when Web Audio is unavailable.
+const AUDIO_ICON: Record<AudioState, IconName> = {
+	unavailable: "volume-off",
+	suspended: "volume",
+	on: "volume-2",
+	muted: "volume-x",
+};
 
 /**
  * The top status bar: machine summary (opens the menu), and the audio,
@@ -19,20 +30,21 @@ export function TopBar({ host }: { host: EmulatorHost }) {
 	// ~1/4 of the width, so while it's open we hold compact until `lg` (1024px) —
 	// otherwise the bar crowds on a landscape phone.
 	const density = panelOpen
-		? "lg:gap-4 lg:px-3 lg:text-base"
-		: "sm:gap-4 sm:px-3 sm:text-base";
+		? "lg:gap-5 lg:px-3 lg:text-base"
+		: "sm:gap-5 sm:px-3 sm:text-base";
 
 	return (
 		<header
-			class={`flex h-9 shrink-0 items-center gap-2 px-2 text-xs whitespace-nowrap ${density}`}
+			class={`flex h-9 shrink-0 items-center gap-3 px-2 text-xs whitespace-nowrap ${density}`}
 		>
 			<button
 				type="button"
 				class="text-neutral-400 hover:text-white"
 				aria-label={messages.topBar.menu}
+				title={messages.topBar.menu}
 				onClick={() => host.dispatch("MENU_TOGGLE")}
 			>
-				☰
+				<Icon name="menu" class="size-6" />
 			</button>
 			<button
 				type="button"
@@ -42,35 +54,51 @@ export function TopBar({ host }: { host: EmulatorHost }) {
 				{config.model} · {config.tv.toUpperCase()}
 			</button>
 
-			<div class="ml-auto flex items-center gap-2 text-neutral-400 sm:gap-4">
+			<div class="ml-auto flex items-center gap-3 text-neutral-400 sm:gap-5">
 				<button
 					type="button"
 					class={
 						audio === "unavailable"
 							? "opacity-50 hover:text-white"
-							: "hover:text-white"
+							: audio === "suspended"
+								? "text-amber-400 hover:text-amber-300"
+								: "hover:text-white"
 					}
+					aria-label={messages.audio[audio]}
+					title={messages.audio[audio]}
 					onClick={() => host.dispatch("AUDIO_TOGGLE")}
 				>
-					{messages.audio[audio]}
+					<Icon name={AUDIO_ICON[audio]} class="size-6" />
 				</button>
 				<button
 					type="button"
-					class="hover:text-white"
+					class={
+						running
+							? "hover:text-white"
+							: "text-amber-400 hover:text-amber-300 motion-safe:animate-pulse"
+					}
+					aria-label={
+						running ? messages.topBar.running : messages.topBar.paused
+					}
+					title={running ? messages.topBar.running : messages.topBar.paused}
 					onClick={() => host.dispatch("TOGGLE_PAUSE")}
 				>
-					{running ? messages.topBar.running : messages.topBar.paused}
+					{/* Action-semantic: while running, the button pauses (and vice
+					    versa), so it shows the icon for what a click will do. */}
+					<Icon name={running ? "pause" : "play"} class="size-6" />
 				</button>
 				<button
 					type="button"
 					class={
 						turboMode
-							? "text-amber-400 hover:text-amber-300"
+							? "text-amber-400 hover:text-amber-300 motion-safe:animate-pulse"
 							: "hover:text-white"
 					}
+					aria-label={messages.topBar.turbo}
+					title={messages.topBar.turbo}
 					onClick={() => host.dispatch("TURBO_MODE_TOGGLE")}
 				>
-					{messages.topBar.turbo}
+					<Icon name="zap" class="size-6" />
 				</button>
 				<span class="w-16 text-right tabular-nums text-neutral-500">
 					{fps ? `${fps} fps` : "—"}

--- a/apps/a8-web/vite.config.ts
+++ b/apps/a8-web/vite.config.ts
@@ -40,6 +40,12 @@ export default defineConfig({
 		// deploy's Nginx can serve them with a long-lived immutable cache
 		// (everything here is fingerprinted, so it's safe to cache forever).
 		assetsDir: "_app/assets",
+		// Never inline SVGs as data URIs: the icon sprite is referenced with
+		// `<use href="…#id">`, and browsers don't resolve a #fragment against a
+		// data: URI — it must stay a real (hashed) file. `false` opts out;
+		// `undefined` keeps Vite's default size threshold for everything else.
+		assetsInlineLimit: (filePath) =>
+			filePath.endsWith(".svg") ? false : undefined,
 		rollupOptions: {
 			input: {
 				main: fileURLToPath(new URL("./index.html", import.meta.url)),


### PR DESCRIPTION
Replaces the Unicode glyphs in the UI chrome with Lucide icons, served from one hashed SVG sprite.

## Approach
- **Sprite + `<use>`**: `src/icons.svg` holds one `<symbol>` per icon; `src/icon.tsx` exposes a type-safe `<Icon name=… />` (the `IconName` union comes from `ICON_NAMES`) that forwards all `<svg>` props. Icons default to `1em`/`currentColor` so they drop in where a glyph sat, inheriting size and color.
- Lucide is stroke-based, so the stroke presentation is set on the `<svg>` wrapper and inherited across the `<use>` boundary; symbols carry geometry only.
- **Vite inlining opt-out**: small SVGs are normally inlined as `data:` URIs, which breaks `<use href="…#id">` (browsers won't resolve a `#fragment` against a data URI). `assetsInlineLimit` now keeps `.svg` as a real hashed file — so it also gets the long-lived `immutable` cache from the `_app/assets` work.

## Call sites
- Chrome glyphs → icons: ☰ menu, ✕ close (toasts + sidebar), 🕹/⌨/▾ OSD tabs, ⇄ OSD swap.
- Top bar: the audio / run-pause / turbo **text** indicators are now icons too. Audio maps state→icon (`volume-2`/`volume-x`/`volume-off`/`volume`); run-pause uses action-semantic icons (pause while running, play while paused); turbo is `zap`. Icons are `size-6`.
- Prominence: paused and turbo pulse amber (`motion-safe:animate-pulse`, so reduced-motion users are spared); suspended audio is a static amber prompt.
- Every icon button carries `aria-label` + `title`; the `<Icon>` itself stays `aria-hidden`.
- The on-screen keyboard keycaps stay as glyphs (intentional nomenclature, per messages.ts).

Lucide's ISC license added to the third-party licenses bundle.