### PR TITLE
a8-web: machine-state persistence + recents

### DIFF
--- a/apps/a8-web/src/commands.ts
+++ b/apps/a8-web/src/commands.ts
@@ -85,6 +85,18 @@ export const commands = {
 		label: "CLEAR_LIBRARY",
 		run: ({ host }) => host.clearLibrary(),
 	},
+	NUKE_EVERYTHING: {
+		label: "NUKE_EVERYTHING",
+		run: ({ host }) => host.nukeEverything(),
+	},
+	RESET_TAB_SETTINGS: {
+		label: "RESET_TAB_SETTINGS",
+		run: ({ host }) => host.resetTabSettings(),
+	},
+	RESET_DEFAULT_SETTINGS: {
+		label: "RESET_DEFAULT_SETTINGS",
+		run: ({ host }) => host.resetDefaultSettings(),
+	},
 
 	// Attach a disk to D1: of the running machine (no reboot, BASIC kept).
 	ATTACH_D1: { label: "ATTACH_D1", run: ({ host }) => host.pickAttachDisk() },

--- a/apps/a8-web/src/host.ts
+++ b/apps/a8-web/src/host.ts
@@ -21,6 +21,7 @@ import { commands, type Command } from "./commands.ts";
 import { Emulator } from "./emulator.ts";
 import { osSlotFor, type OsSlot } from "./firmware-slots.ts";
 import {
+	addOrFindImage,
 	getImage,
 	getImageBytes,
 	libraryEntries,
@@ -865,9 +866,16 @@ export class EmulatorHost {
 		}
 	}
 
-	/** Boot a user-supplied file (the "Boot image…" picker / drag-and-drop). */
+	/**
+	 * Boot a user-supplied file (the "Boot image…" picker / drag-and-drop). The
+	 * file is auto-added to the library (transient) so it has an id — for resume
+	 * and save — and booted through it; unrecognized bytes still warn directly.
+	 */
 	async loadFile(file: File): Promise<void> {
-		this.#bootImage(new Uint8Array(await file.arrayBuffer()), file.name);
+		const bytes = new Uint8Array(await file.arrayBuffer());
+		const id = await addOrFindImage(bytes, file.name, true);
+		if (id) await this.bootImage(id);
+		else this.#bootImage(bytes, file.name);
 	}
 
 	/** Boot a software item from the built-in library. */
@@ -1137,7 +1145,10 @@ export class EmulatorHost {
 	 * saves.
 	 */
 	async attachDiskFile(file: File): Promise<void> {
-		this.#attachDiskBytes(new Uint8Array(await file.arrayBuffer()), file.name);
+		const bytes = new Uint8Array(await file.arrayBuffer());
+		const id = await addOrFindImage(bytes, file.name, true);
+		if (id) await this.attachDisk(id);
+		else this.#attachDiskBytes(bytes, file.name);
 	}
 
 	// Attach an ATR's bytes to D1: live — shared by the file picker and the
@@ -1184,10 +1195,10 @@ export class EmulatorHost {
 	 * "stage it without rebooting" can come later.
 	 */
 	async attachCartridgeFile(file: File): Promise<void> {
-		this.#attachCartridgeBytes(
-			new Uint8Array(await file.arrayBuffer()),
-			file.name,
-		);
+		const bytes = new Uint8Array(await file.arrayBuffer());
+		const id = await addOrFindImage(bytes, file.name, true);
+		if (id) await this.attachCartridge(id);
+		else this.#attachCartridgeBytes(bytes, file.name);
 	}
 
 	// Attach a cartridge's bytes (cold boots) — shared by the file picker and the

--- a/apps/a8-web/src/host.ts
+++ b/apps/a8-web/src/host.ts
@@ -36,11 +36,18 @@ import {
 	hasBuiltinBasic,
 	MODEL_LABELS,
 	ramConfig,
+	sanitizeSettings,
 	settingsEqual,
 	type MachineSettings,
 } from "./machine-config.ts";
 import { currentPath, navigate } from "./navigate.ts";
 import { messages } from "./messages.ts";
+import {
+	clearAllPersisted,
+	clearSessionPersisted,
+	loadPersisted,
+	savePersisted,
+} from "./persist.ts";
 
 export interface HostConfig {
 	model: AtariModel;
@@ -86,6 +93,10 @@ export interface RomOverrides {
 
 const NO_ROM_OVERRIDES: RomOverrides = { os: {}, basic: null, game: null };
 
+// Persisted-state keys (namespaced by storageName) — see persist.ts.
+const CONFIG_KEY = "config";
+const ROMS_KEY = "roms";
+
 function romsEqual(a: RomOverrides, b: RomOverrides): boolean {
 	if (a.basic !== b.basic || a.game !== b.game) return false;
 	const slots = new Set([...Object.keys(a.os), ...Object.keys(b.os)]);
@@ -93,6 +104,21 @@ function romsEqual(a: RomOverrides, b: RomOverrides): boolean {
 		if (a.os[slot as OsSlot] !== b.os[slot as OsSlot]) return false;
 	}
 	return true;
+}
+
+// Coerce a persisted/untrusted value into a RomOverrides shape; ids are
+// validated lazily at resolve time (a stale one falls back to the ranking).
+function sanitizeRoms(value: unknown): RomOverrides {
+	if (typeof value !== "object" || value === null) return NO_ROM_OVERRIDES;
+	const v = value as Partial<RomOverrides>;
+	return {
+		os:
+			v.os && typeof v.os === "object"
+				? (v.os as Partial<Record<OsSlot, string>>)
+				: {},
+		basic: typeof v.basic === "string" ? v.basic : null,
+		game: typeof v.game === "string" ? v.game : null,
+	};
 }
 
 /** Why a detected-but-not-loadable file can't be loaded (yet). */
@@ -201,6 +227,8 @@ export class EmulatorHost {
 	readonly #audio: AudioOutput | null;
 	readonly #audioError: string | null;
 	readonly #keyboard: Keyboard;
+	// The model a brand-new install starts from (and resets fall back to).
+	readonly #defaultModel: AtariModel;
 
 	// Assigned by create() before the host is handed out — the constructor can't
 	// await the initial firmware fetch.
@@ -241,14 +269,18 @@ export class EmulatorHost {
 	constructor({ model, audio, audioError }: HostConfig) {
 		this.#audio = audio;
 		this.#audioError = audioError ?? null;
-		this.config.value = {
-			model,
-			memory: model === "400/800" ? 48 : 64,
-			portbExtendedRam: null,
-			tv: "ntsc",
-			basicDisabled: false,
-		};
+		this.#defaultModel = model;
+		// Start from the last persisted machine config (this tab's, else the
+		// last-used seed), falling back to a default for the requested model.
+		this.config.value = sanitizeSettings(
+			loadPersisted(CONFIG_KEY),
+			this.#defaultSettings(),
+		);
 		this.staged.value = this.config.peek();
+		// Restore firmware picks (ids resolve lazily; a stale one falls back to
+		// the ranking).
+		this.appliedRoms.value = sanitizeRoms(loadPersisted(ROMS_KEY));
+		this.stagedRoms.value = this.appliedRoms.peek();
 
 		// #emulator is built by create() once the initial firmware is fetched.
 		this.#keyboard = new Keyboard((command) => this.dispatch(command));
@@ -736,6 +768,7 @@ export class EmulatorHost {
 		if (!this.dirty.value) return;
 		const prev = this.config.value;
 		this.config.value = this.staged.value;
+		savePersisted(CONFIG_KEY, this.config.value);
 		this.#announceConfigChange(prev, this.config.value);
 		void this.#reboot();
 		this.closePanel();
@@ -751,6 +784,7 @@ export class EmulatorHost {
 		const prev = this.config.value;
 		this.config.value = next;
 		this.staged.value = next;
+		savePersisted(CONFIG_KEY, next);
 		this.#announceConfigChange(prev, next);
 		void this.#reboot();
 	}
@@ -794,6 +828,7 @@ export class EmulatorHost {
 		if (!this.romsDirty.value) return;
 		const reboot = this.romsReboot.value;
 		this.appliedRoms.value = this.stagedRoms.value;
+		savePersisted(ROMS_KEY, this.appliedRoms.value);
 		if (reboot) void this.#reboot();
 	}
 
@@ -868,10 +903,106 @@ export class EmulatorHost {
 		this.#attachCartridgeBytes(await getImageBytes(id), entry.user.displayName);
 	}
 
-	/** Wipe all of the user's library uploads (after a confirm). Built-ins stay. */
+	/**
+	 * Wipe all of the user's library uploads (after a confirm); reboots if the
+	 * running machine was using one (it falls back to a built-in). Built-ins stay.
+	 */
 	clearLibrary(): void {
 		if (!window.confirm(messages.library.confirmClear)) return;
-		void nukeLibrary().then(() => this.toast(messages.library.cleared));
+		const before = this.#resolvedFirmwareIds();
+		void nukeLibrary().then(() => {
+			this.toast(messages.library.cleared);
+			this.#rebootIfFirmwareChanged(before, false);
+		});
+	}
+
+	/** Reset everything (testing): wipe the library AND all saved settings. */
+	nukeEverything(): void {
+		if (!window.confirm(messages.reset.confirmEverything)) return;
+		const before = this.#resolvedFirmwareIds();
+		const prev = this.config.value;
+		clearAllPersisted();
+		void nukeLibrary().then(() => {
+			this.#setConfigAndRoms(this.#defaultSettings(), NO_ROM_OVERRIDES);
+			this.#rebootIfFirmwareChanged(
+				before,
+				!settingsEqual(prev, this.config.value),
+			);
+			this.toast(messages.reset.everything);
+		});
+	}
+
+	/** Drop this tab's overrides, reverting to the last-saved (seed) config + picks. */
+	resetTabSettings(): void {
+		const before = this.#resolvedFirmwareIds();
+		const prev = this.config.value;
+		clearSessionPersisted();
+		this.#setConfigAndRoms(
+			sanitizeSettings(loadPersisted(CONFIG_KEY), this.#defaultSettings()),
+			sanitizeRoms(loadPersisted(ROMS_KEY)),
+		);
+		this.#rebootIfFirmwareChanged(
+			before,
+			!settingsEqual(prev, this.config.value),
+		);
+		this.toast(messages.reset.tab);
+	}
+
+	/** Clear all saved settings, reverting to factory config + picks (library kept). */
+	resetDefaultSettings(): void {
+		const before = this.#resolvedFirmwareIds();
+		const prev = this.config.value;
+		clearAllPersisted();
+		this.#setConfigAndRoms(this.#defaultSettings(), NO_ROM_OVERRIDES);
+		this.#rebootIfFirmwareChanged(
+			before,
+			!settingsEqual(prev, this.config.value),
+		);
+		this.toast(messages.reset.defaults);
+	}
+
+	// --- reset helpers ------------------------------------------------------
+
+	#defaultSettings(): MachineSettings {
+		const model = this.#defaultModel;
+		return {
+			model,
+			memory: model === "400/800" ? 48 : 64,
+			portbExtendedRam: null,
+			tv: "ntsc",
+			basicDisabled: false,
+		};
+	}
+
+	// Set config + applied/staged ROM picks without persisting (resets clear the
+	// store deliberately; a later explicit change re-persists).
+	#setConfigAndRoms(config: MachineSettings, roms: RomOverrides): void {
+		this.config.value = config;
+		this.staged.value = config;
+		this.appliedRoms.value = roms;
+		this.stagedRoms.value = roms;
+	}
+
+	#resolvedFirmwareIds(): { os?: string; basic?: string; game?: string } {
+		const { os, basic, game } = this.#resolveFirmware();
+		return { os: os?.id, basic: basic?.id, game: game?.id };
+	}
+
+	// Reboot when the config changed or the firmware the running machine resolves
+	// to differs from `before` (so resets only power-cycle when they have to).
+	#rebootIfFirmwareChanged(
+		before: { os?: string; basic?: string; game?: string },
+		configChanged: boolean,
+	): void {
+		const after = this.#resolvedFirmwareIds();
+		if (
+			configChanged ||
+			before.os !== after.os ||
+			before.basic !== after.basic ||
+			before.game !== after.game
+		) {
+			void this.#reboot();
+		}
 	}
 
 	// Mount an image (disk/cartridge/executable) and power-cycle into it.

--- a/apps/a8-web/src/host.ts
+++ b/apps/a8-web/src/host.ts
@@ -47,7 +47,9 @@ import {
 	clearAllPersisted,
 	clearSessionPersisted,
 	loadPersisted,
+	loadSession,
 	savePersisted,
+	saveSession,
 } from "./persist.ts";
 
 export interface HostConfig {
@@ -97,6 +99,30 @@ const NO_ROM_OVERRIDES: RomOverrides = { os: {}, basic: null, game: null };
 // Persisted-state keys (namespaced by storageName) — see persist.ts.
 const CONFIG_KEY = "config";
 const ROMS_KEY = "roms";
+// The mounted media is per-tab (sessionStorage only) — a fresh tab starts empty
+// rather than auto-booting the last session's image.
+const MEDIA_KEY = "media";
+
+/** This tab's persisted mounted media: the library ids in each slot. */
+interface PersistedMedia {
+	cart: string | null;
+	disk: string | null;
+	/** The live BASIC-disabled state (a boot turns it off without touching the
+	 *  saved config seed), so a resume matches the booted machine. */
+	basicDisabled: boolean;
+}
+
+// Coerce an untrusted persisted value into a PersistedMedia, or null if absent
+// or malformed (ids are resolved against the library lazily, on restore).
+function sanitizeMedia(value: unknown): PersistedMedia | null {
+	if (typeof value !== "object" || value === null) return null;
+	const v = value as Partial<PersistedMedia>;
+	return {
+		cart: typeof v.cart === "string" ? v.cart : null,
+		disk: typeof v.disk === "string" ? v.disk : null,
+		basicDisabled: Boolean(v.basicDisabled),
+	};
+}
 
 function romsEqual(a: RomOverrides, b: RomOverrides): boolean {
 	if (a.basic !== b.basic || a.game !== b.game) return false;
@@ -247,12 +273,16 @@ export class EmulatorHost {
 	// What's mounted, kept across reboots and re-applied by #makeEmulator. The
 	// cartridge slot and the disk drives are independent (a cart and a disk can
 	// coexist); #drives is indexed by drive number (0 = D1:), one slot for now.
-	#cartridge: { cart: Cartridge; name: string } | null = null;
-	// `sourceId` is the library entry a disk came from, if any — what
-	// `saveD1ToLibrary` writes back to.
+	// `sourceId` is the library entry the cart/disk came from, if any — used to
+	// persist what's mounted (and, for a disk, what `saveD1ToLibrary` writes back).
+	#cartridge: { cart: Cartridge; name: string; sourceId?: string } | null =
+		null;
 	#drives: ({ disk: AtrImage; name: string; sourceId?: string } | null)[] = [
 		null,
 	];
+	// Media to re-mount once the library is ready (set from sessionStorage in the
+	// constructor, consumed by create()/#restoreMedia). Null when nothing to do.
+	#pendingMedia: PersistedMedia | null = null;
 
 	/**
 	 * Build a host and boot its first emulator. Async because the initial OS +
@@ -262,6 +292,7 @@ export class EmulatorHost {
 	static async create(config: HostConfig): Promise<EmulatorHost> {
 		const host = new EmulatorHost(config);
 		await host.#ensureFirmware();
+		await host.#restoreMedia();
 		host.#emulator = host.#makeEmulator();
 		host.#wireLeds();
 		return host;
@@ -277,6 +308,16 @@ export class EmulatorHost {
 			loadPersisted(CONFIG_KEY),
 			this.#defaultSettings(),
 		);
+		// This tab's mounted media (if any) is restored by create() once the
+		// library loads; its live BASIC state overrides the saved config seed so
+		// a resumed boot matches the machine it left.
+		this.#pendingMedia = sanitizeMedia(loadSession(MEDIA_KEY));
+		if (this.#pendingMedia) {
+			this.config.value = {
+				...this.config.value,
+				basicDisabled: this.#pendingMedia.basicDisabled,
+			};
+		}
 		this.staged.value = this.config.peek();
 		// Restore firmware picks (ids resolve lazily; a stale one falls back to
 		// the ranking).
@@ -317,6 +358,64 @@ export class EmulatorHost {
 			cartridge: this.#cartridge?.name ?? basic,
 			drives: this.#drives.map((drive) => drive?.name ?? null),
 		};
+	}
+
+	// Persist this tab's mounted media (the library ids in each slot) plus the
+	// live BASIC state, so reloading the tab resumes the running machine. Only
+	// slots backed by a library entry persist; an id-less mount is dropped (it
+	// can't be reconstructed). Session-only — a fresh tab starts empty.
+	#saveMedia(): void {
+		saveSession(MEDIA_KEY, {
+			cart: this.#cartridge?.sourceId ?? null,
+			disk: this.#drives[0]?.sourceId ?? null,
+			basicDisabled: this.config.value.basicDisabled,
+		} satisfies PersistedMedia);
+	}
+
+	// Re-mount the media persisted for this tab, resolving ids against the
+	// library; an image deleted since (or any read error) is silently skipped, so
+	// a stale pointer just yields an empty slot. Runs in create() after the
+	// library has loaded, before the first emulator is built.
+	async #restoreMedia(): Promise<void> {
+		const media = this.#pendingMedia;
+		this.#pendingMedia = null;
+		if (!media) return;
+		await readyLibrary();
+		if (media.disk) {
+			try {
+				const entry = getImage(media.disk);
+				if (entry) {
+					const bytes = await getImageBytes(media.disk);
+					const disk =
+						entry.derived.type === "xex"
+							? buildBootDisk(bytes)
+							: new AtrImage(bytes);
+					this.#drives[0] = {
+						disk,
+						name: entry.user.displayName,
+						sourceId: media.disk,
+					};
+				}
+			} catch {
+				// corrupt or missing blob — leave D1: empty
+			}
+		}
+		if (media.cart) {
+			try {
+				const entry = getImage(media.cart);
+				if (entry) {
+					const bytes = await getImageBytes(media.cart);
+					this.#cartridge = {
+						cart: new Cartridge(bytes),
+						name: entry.user.displayName,
+						sourceId: media.cart,
+					};
+				}
+			} catch {
+				// corrupt or missing blob — leave the cart slot empty
+			}
+		}
+		this.#refreshAttachments();
 	}
 
 	/** Run a bound command (from a key binding, the UI, or the palette). */
@@ -770,6 +869,7 @@ export class EmulatorHost {
 		const prev = this.config.value;
 		this.config.value = this.staged.value;
 		savePersisted(CONFIG_KEY, this.config.value);
+		this.#saveMedia(); // keep the resume's live BASIC state in sync
 		this.#announceConfigChange(prev, this.config.value);
 		void this.#reboot();
 		this.closePanel();
@@ -786,6 +886,7 @@ export class EmulatorHost {
 		this.config.value = next;
 		this.staged.value = next;
 		savePersisted(CONFIG_KEY, next);
+		this.#saveMedia(); // keep the resume's live BASIC state in sync
 		this.#announceConfigChange(prev, next);
 		void this.#reboot();
 	}
@@ -908,7 +1009,11 @@ export class EmulatorHost {
 		await readyLibrary();
 		const entry = getImage(id);
 		if (!entry) return;
-		this.#attachCartridgeBytes(await getImageBytes(id), entry.user.displayName);
+		this.#attachCartridgeBytes(
+			await getImageBytes(id),
+			entry.user.displayName,
+			id,
+		);
 	}
 
 	/**
@@ -929,12 +1034,14 @@ export class EmulatorHost {
 		if (!window.confirm(messages.reset.confirmEverything)) return;
 		const before = this.#resolvedFirmwareIds();
 		const prev = this.config.value;
+		const hadMedia = this.#mediaMounted();
 		clearAllPersisted();
 		void nukeLibrary().then(() => {
 			this.#setConfigAndRoms(this.#defaultSettings(), NO_ROM_OVERRIDES);
+			this.#clearMedia();
 			this.#rebootIfFirmwareChanged(
 				before,
-				!settingsEqual(prev, this.config.value),
+				!settingsEqual(prev, this.config.value) || hadMedia,
 			);
 			this.toast(messages.reset.everything);
 		});
@@ -944,14 +1051,16 @@ export class EmulatorHost {
 	resetTabSettings(): void {
 		const before = this.#resolvedFirmwareIds();
 		const prev = this.config.value;
+		const hadMedia = this.#mediaMounted();
 		clearSessionPersisted();
 		this.#setConfigAndRoms(
 			sanitizeSettings(loadPersisted(CONFIG_KEY), this.#defaultSettings()),
 			sanitizeRoms(loadPersisted(ROMS_KEY)),
 		);
+		this.#clearMedia();
 		this.#rebootIfFirmwareChanged(
 			before,
-			!settingsEqual(prev, this.config.value),
+			!settingsEqual(prev, this.config.value) || hadMedia,
 		);
 		this.toast(messages.reset.tab);
 	}
@@ -960,11 +1069,13 @@ export class EmulatorHost {
 	resetDefaultSettings(): void {
 		const before = this.#resolvedFirmwareIds();
 		const prev = this.config.value;
+		const hadMedia = this.#mediaMounted();
 		clearAllPersisted();
 		this.#setConfigAndRoms(this.#defaultSettings(), NO_ROM_OVERRIDES);
+		this.#clearMedia();
 		this.#rebootIfFirmwareChanged(
 			before,
-			!settingsEqual(prev, this.config.value),
+			!settingsEqual(prev, this.config.value) || hadMedia,
 		);
 		this.toast(messages.reset.defaults);
 	}
@@ -989,6 +1100,18 @@ export class EmulatorHost {
 		this.staged.value = config;
 		this.appliedRoms.value = roms;
 		this.stagedRoms.value = roms;
+	}
+
+	#mediaMounted(): boolean {
+		return this.#cartridge !== null || this.#drives.some((d) => d !== null);
+	}
+
+	// Unmount everything in memory (the persisted media is cleared separately by
+	// the reset's storage wipe). The caller reboots into the now-empty machine.
+	#clearMedia(): void {
+		this.#cartridge = null;
+		this.#drives = [null];
+		this.#refreshAttachments();
 	}
 
 	#resolvedFirmwareIds(): { os?: string; basic?: string; game?: string } {
@@ -1031,18 +1154,19 @@ export class EmulatorHost {
 
 		// Boot image starts fresh: fill the one slot it boots from and clear the
 		// rest. (Attach, below, instead adds to the running machine in place.)
-		let cartridge: { cart: Cartridge; name: string } | null = null;
+		let cartridge: { cart: Cartridge; name: string; sourceId?: string } | null =
+			null;
 		let disk: { disk: AtrImage; name: string; sourceId?: string } | null = null;
 		try {
 			if (format === "atr") {
-				// Only a real disk carries a library source to save back to (a XEX's
-				// synthetic boot disk doesn't).
 				disk = { disk: new AtrImage(contents), name, sourceId };
 			} else if (format === "xex") {
-				// XEX boots from a generated in-memory disk (its loader).
-				disk = { disk: buildBootDisk(contents), name };
+				// XEX boots from a generated in-memory disk (its loader). The source
+				// id is kept so the boot can be resumed (re-built from the XEX), but
+				// saveD1ToLibrary refuses it — its synthetic disk isn't the XEX.
+				disk = { disk: buildBootDisk(contents), name, sourceId };
 			} else {
-				cartridge = { cart: new Cartridge(contents), name };
+				cartridge = { cart: new Cartridge(contents), name, sourceId };
 			}
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
@@ -1066,6 +1190,7 @@ export class EmulatorHost {
 		this.#drives = [disk];
 		this.config.value = { ...this.config.value, basicDisabled: true };
 		this.#refreshAttachments();
+		this.#saveMedia();
 		void this.#reboot();
 	}
 
@@ -1128,9 +1253,13 @@ export class EmulatorHost {
 			this.toast(messages.errors.noDiskToSave, "warning");
 			return;
 		}
+		// Only a real disk entry can be overwritten — not a XEX (its D1: is a
+		// synthetic boot disk), nor a built-in or since-deleted source.
+		const source = drive.sourceId ? getImage(drive.sourceId) : undefined;
 		if (
-			!drive.sourceId ||
-			!(await updateImage(drive.sourceId, drive.disk.toBytes()))
+			!source ||
+			source.derived.type !== "disk" ||
+			!(await updateImage(source.id, drive.disk.toBytes()))
 		) {
 			this.toast(messages.errors.notLibraryDisk, "warning");
 			return;
@@ -1171,6 +1300,7 @@ export class EmulatorHost {
 		this.#emulator.machine.insertDisk(disk);
 		this.closePanel(); // get out of the way
 		this.#refreshAttachments();
+		this.#saveMedia();
 		this.toast(messages.toasts.attachingDisk(name));
 	}
 
@@ -1184,6 +1314,7 @@ export class EmulatorHost {
 		this.#drives[0] = null;
 		this.#emulator.machine.ejectDisk();
 		this.#refreshAttachments();
+		this.#saveMedia();
 		this.toast(messages.toasts.detachingDisk(drive.name));
 	}
 
@@ -1204,7 +1335,11 @@ export class EmulatorHost {
 	// Attach a cartridge's bytes (cold boots) — shared by the file picker and the
 	// library's `attachCartridge(id)`. Content-based detection so canonical `.car`
 	// and raw built-in bytes both load without a filename hint.
-	#attachCartridgeBytes(contents: Uint8Array, name: string): void {
+	#attachCartridgeBytes(
+		contents: Uint8Array,
+		name: string,
+		sourceId?: string,
+	): void {
 		const format = detectFileFormat(contents);
 		const isCartridge =
 			format !== null &&
@@ -1238,8 +1373,9 @@ export class EmulatorHost {
 		this.toast(messages.toasts.attachingCartridge(name));
 
 		this.closePanel(); // get out of the way
-		this.#cartridge = { cart, name };
+		this.#cartridge = { cart, name, sourceId };
 		this.#refreshAttachments();
+		this.#saveMedia();
 		void this.#reboot();
 	}
 
@@ -1256,6 +1392,7 @@ export class EmulatorHost {
 			const { name } = this.#cartridge;
 			this.#cartridge = null;
 			this.#refreshAttachments();
+			this.#saveMedia();
 			void this.#reboot();
 			this.toast(messages.toasts.detachingCartridge(name));
 			return;

--- a/apps/a8-web/src/host.ts
+++ b/apps/a8-web/src/host.ts
@@ -24,14 +24,16 @@ import {
 	addOrFindImage,
 	getImage,
 	getImageBytes,
+	keepImage,
 	libraryEntries,
 	nukeLibrary,
 	readyLibrary,
+	removeImage,
+	sweepTransients,
 	updateImage,
 } from "./images/library.ts";
 import type { ImageEntry } from "./images/metadata.ts";
 import { Keyboard } from "./keyboard.ts";
-import { loadLibraryEntry, type LibraryEntry } from "./library.ts";
 import {
 	clampRam,
 	hasBuiltinBasic,
@@ -43,6 +45,7 @@ import {
 } from "./machine-config.ts";
 import { currentPath, navigate } from "./navigate.ts";
 import { messages } from "./messages.ts";
+import { recentIds, removeRecent, touchRecent } from "./recents.ts";
 import {
 	clearAllPersisted,
 	clearSessionPersisted,
@@ -370,6 +373,22 @@ export class EmulatorHost {
 			disk: this.#drives[0]?.sourceId ?? null,
 			basicDisabled: this.config.value.basicDisabled,
 		} satisfies PersistedMedia);
+	}
+
+	// Record a just-booted/attached library image in the recents history, then
+	// sweep transient (auto-added) images that have fallen off it — keeping any
+	// still mounted, so a resume never loses its backing blob.
+	#noteUsed(sourceId: string | undefined): void {
+		if (!sourceId) return;
+		touchRecent(sourceId);
+		const keep = new Set(recentIds.value);
+		if (this.#cartridge?.sourceId) keep.add(this.#cartridge.sourceId);
+		if (this.#drives[0]?.sourceId) keep.add(this.#drives[0].sourceId);
+		void sweepTransients(keep);
+	}
+
+	#mountsImage(id: string): boolean {
+		return this.#cartridge?.sourceId === id || this.#drives[0]?.sourceId === id;
 	}
 
 	// Re-mount the media persisted for this tab, resolving ids against the
@@ -979,11 +998,6 @@ export class EmulatorHost {
 		else this.#bootImage(bytes, file.name);
 	}
 
-	/** Boot a software item from the built-in library. */
-	async bootLibraryEntry(entry: LibraryEntry): Promise<void> {
-		this.#bootImage(await loadLibraryEntry(entry), entry.fileName);
-	}
-
 	// --- Image library actions (by id; built-in or user). The id-based entry
 	// points fetch the bytes through the facade and reuse the boot/attach cores
 	// below. ---
@@ -1014,6 +1028,23 @@ export class EmulatorHost {
 			entry.user.displayName,
 			id,
 		);
+	}
+
+	/** Promote a transient (auto-added) recents item into the curated library. */
+	keepRecent(id: string): void {
+		const entry = getImage(id);
+		if (!entry?.transient) return;
+		void keepImage(id).then(() =>
+			this.toast(messages.recents.kept(entry.user.displayName)),
+		);
+	}
+
+	// Drop an item from the recents history. A transient image that's no longer
+	// recent and isn't mounted is then orphaned, so it's deleted outright.
+	removeFromRecents(id: string): void {
+		const entry = getImage(id);
+		removeRecent(id);
+		if (entry?.transient && !this.#mountsImage(id)) void removeImage(id);
 	}
 
 	/**
@@ -1191,6 +1222,7 @@ export class EmulatorHost {
 		this.config.value = { ...this.config.value, basicDisabled: true };
 		this.#refreshAttachments();
 		this.#saveMedia();
+		this.#noteUsed(sourceId);
 		void this.#reboot();
 	}
 
@@ -1301,6 +1333,7 @@ export class EmulatorHost {
 		this.closePanel(); // get out of the way
 		this.#refreshAttachments();
 		this.#saveMedia();
+		this.#noteUsed(sourceId);
 		this.toast(messages.toasts.attachingDisk(name));
 	}
 
@@ -1376,6 +1409,7 @@ export class EmulatorHost {
 		this.#cartridge = { cart, name, sourceId };
 		this.#refreshAttachments();
 		this.#saveMedia();
+		this.#noteUsed(sourceId);
 		void this.#reboot();
 	}
 

--- a/apps/a8-web/src/icon.tsx
+++ b/apps/a8-web/src/icon.tsx
@@ -9,6 +9,7 @@ import iconsUrl from "./icons.svg";
 export const ICON_NAMES = [
 	"menu",
 	"close",
+	"bookmark",
 	"joystick",
 	"keyboard",
 	"chevron-down",

--- a/apps/a8-web/src/icons.svg
+++ b/apps/a8-web/src/icons.svg
@@ -17,6 +17,9 @@
 		<path d="M18 6 6 18" />
 		<path d="m6 6 12 12" />
 	</symbol>
+	<symbol id="bookmark" viewBox="0 0 24 24">
+		<path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+	</symbol>
 	<symbol id="joystick" viewBox="0 0 24 24">
 		<path d="M21 17a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v2a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-2Z" />
 		<path d="M6 15v-2" />

--- a/apps/a8-web/src/images/library.ts
+++ b/apps/a8-web/src/images/library.ts
@@ -142,6 +142,55 @@ export function getImage(id: string): ImageEntry | undefined {
 	return libraryEntries.value.find((e) => e.id === id);
 }
 
+// Built-in bootable software (a recognized non-firmware image), by unified id —
+// the recents seed. Detection ignores the on-disk folder, so "software" is just
+// a recognized image with no firmware identity.
+const BUILTIN_SOFTWARE_IDS = new Set(
+	builtinFirmware
+		.filter((fw) => fw.kind !== null && fw.firmwareType === null)
+		.map(builtinId),
+);
+
+/** Built-in bootable software entries (non-firmware), sorted by display name. */
+export const builtinSoftware = computed<ImageEntry[]>(() =>
+	libraryEntries.value
+		.filter((e) => BUILTIN_SOFTWARE_IDS.has(e.id))
+		.sort((a, b) => a.user.displayName.localeCompare(b.user.displayName)),
+);
+
+/** Promote a transient (auto-added) image into the curated library. */
+export async function keepImage(id: string): Promise<void> {
+	await readyLibrary();
+	const entry = userEntries.value.find((e) => e.id === id);
+	if (!entry?.transient) return;
+	const kept: StoredEntry = { ...entry };
+	delete kept.transient;
+	await putEntry(kept);
+	userEntries.value = userEntries.value.map((e) => (e.id === id ? kept : e));
+}
+
+/**
+ * Delete transient (auto-added) images whose ids aren't in `keep` — e.g. ones
+ * that fell off the recents list — reclaiming any blob no survivor references.
+ * Curated and built-in entries are never touched.
+ */
+export async function sweepTransients(keep: Set<string>): Promise<void> {
+	await readyLibrary();
+	const doomed = userEntries.value.filter(
+		(e) => e.transient && !keep.has(e.id),
+	);
+	if (doomed.length === 0) return;
+	for (const entry of doomed) await deleteEntry(entry.id);
+	const gone = new Set(doomed.map((e) => e.id));
+	const remaining = userEntries.value.filter((e) => !gone.has(e.id));
+	for (const entry of doomed) {
+		if (!remaining.some((e) => e.hash === entry.hash)) {
+			await blobs.delete(entry.hash);
+		}
+	}
+	userEntries.value = remaining;
+}
+
 /**
  * Resolve an image's bytes: a built-in serves its raw asset (a `#slice` of it);
  * a user image serves its canonical blob (decompressed by the blob store).

--- a/apps/a8-web/src/images/library.ts
+++ b/apps/a8-web/src/images/library.ts
@@ -119,6 +119,7 @@ function userImageEntry(e: StoredEntry): ImageEntry {
 		hash: e.hash,
 		source: "user",
 		size: e.size,
+		...(e.transient && { transient: true }),
 		locator: { kind: "user", backend: e.locator.backend, ref: e.locator.ref },
 		derived: e.derived,
 		user: e.user,
@@ -179,6 +180,7 @@ async function ingestFile(
 	fileName: string,
 	seen: Set<string>,
 	into: StoredEntry[],
+	transient = false,
 ): Promise<{ added: number; deduped: number }> {
 	const pieces = canonicalize(bytes, fileName); // throws on an unrecognized file
 	const baseName = fileName.replace(/\.[^./]+$/, "");
@@ -199,6 +201,7 @@ async function ingestFile(
 			hash,
 			size: piece.bytes.length,
 			createdAt: Date.now(),
+			...(transient && { transient: true }),
 			locator: { backend: "idb", ref: hash },
 			derived: piece.kind,
 			user: {
@@ -213,6 +216,43 @@ async function ingestFile(
 		added++;
 	}
 	return { added, deduped };
+}
+
+/**
+ * Resolve an in-memory image (e.g. one being booted/attached from the file
+ * picker) to a library id: return the existing entry's id if its canonical bytes
+ * are already in the library, else add it (as `transient` when so flagged) and
+ * return the new id. Returns null if the bytes aren't a recognized image.
+ */
+export async function addOrFindImage(
+	bytes: Uint8Array,
+	fileName: string,
+	transient: boolean,
+): Promise<string | null> {
+	await readyLibrary();
+	let hash: string;
+	try {
+		const piece = canonicalize(bytes, fileName)[0];
+		if (!piece) return null;
+		hash = await sha256Hex(piece.bytes);
+	} catch {
+		return null; // unrecognized
+	}
+	const existing = userEntries.value.find((e) => e.hash === hash);
+	if (existing) return existing.id;
+
+	const into: StoredEntry[] = [];
+	await ingestFile(
+		bytes,
+		fileName,
+		new Set(userEntries.value.map((e) => e.hash)),
+		into,
+		transient,
+	);
+	const added = into[0];
+	if (!added) return null;
+	userEntries.value = [...userEntries.value, ...into];
+	return added.id;
 }
 
 /**

--- a/apps/a8-web/src/images/metadata.ts
+++ b/apps/a8-web/src/images/metadata.ts
@@ -60,6 +60,9 @@ export interface ImageEntry {
 	source: "builtin" | "user";
 	/** Total canonical file size in bytes. */
 	size: number;
+	/** Auto-added by booting/attaching a file (not deliberately imported) — hidden
+	 *  from the curated list until "kept". */
+	transient?: boolean;
 	locator: BlobLocator;
 	derived: DerivedMeta;
 	user: UserMeta;
@@ -75,6 +78,8 @@ export interface StoredEntry {
 	size: number;
 	/** Creation time, ms since epoch; indexed. */
 	createdAt: number;
+	/** Auto-added by a file boot/attach rather than deliberately imported. */
+	transient?: boolean;
 	locator: { backend: BlobBackend; ref: string };
 	derived: DerivedMeta;
 	user: UserMeta;

--- a/apps/a8-web/src/machine-config.ts
+++ b/apps/a8-web/src/machine-config.ts
@@ -89,6 +89,33 @@ export function clampRam(
 	return ramConfig(RAM_SIZES[model].includes(total) ? total : RAM_BASE[model]);
 }
 
+/**
+ * Coerce a persisted/untrusted value into valid {@link MachineSettings},
+ * clamping RAM to the model — returns `fallback` if it isn't a recognizable
+ * settings object (e.g. an unknown model from an older or corrupt store).
+ */
+export function sanitizeSettings(
+	value: unknown,
+	fallback: MachineSettings,
+): MachineSettings {
+	if (typeof value !== "object" || value === null) return fallback;
+	const v = value as Partial<MachineSettings>;
+	if (!MODELS.includes(v.model as AtariModel)) return fallback;
+	const model = v.model as AtariModel;
+	const ext = v.portbExtendedRam;
+	const base: MachineSettings = {
+		model,
+		memory: typeof v.memory === "number" ? v.memory : RAM_BASE[model],
+		portbExtendedRam:
+			ext && typeof ext === "object"
+				? { size: Number(ext.size) || 0, antic: Boolean(ext.antic) }
+				: null,
+		tv: v.tv === "pal" ? "pal" : "ntsc",
+		basicDisabled: Boolean(v.basicDisabled),
+	};
+	return { ...base, ...clampRam(model, base) };
+}
+
 export type AnticPolicy = "on" | "off" | "optional";
 
 /**

--- a/apps/a8-web/src/messages.ts
+++ b/apps/a8-web/src/messages.ts
@@ -121,7 +121,6 @@ export const messages = {
 		unsaved: "Unsaved change",
 		save: "Save changes",
 		noSuitable: "No suitable ROMs",
-		picksReset: "Picks reset when you reload.",
 		manageLibrary: "Manage library",
 		builtin: "Built-in",
 		yourRoms: "Your ROMs",
@@ -203,6 +202,14 @@ export const messages = {
 				parts.length > 0 ? `${parts.join(". ")}.` : "Nothing to add.";
 			return `${summary} (${formatDuration(seconds)})`;
 		},
+	},
+
+	reset: {
+		confirmEverything:
+			"Wipe your entire library AND all saved settings? This can't be undone.",
+		everything: "Reset everything — library and settings",
+		tab: "This tab reset to your saved settings",
+		defaults: "All settings reset to defaults",
 	},
 
 	keyHelp: {
@@ -289,6 +296,9 @@ export const labels = {
 	OPEN_ROMS: "ROM preferences…",
 	OPEN_LIBRARY: "Library…",
 	CLEAR_LIBRARY: "Clear your library…",
+	NUKE_EVERYTHING: "Reset everything: wipe library and settings…",
+	RESET_TAB_SETTINGS: "Reset this tab to saved settings",
+	RESET_DEFAULT_SETTINGS: "Reset all settings to defaults",
 	TOGGLE_FULLSCREEN: "Toggle full screen",
 	BOOT_IMAGE: "Boot a disk, cartridge, or executable…",
 	ATTACH_D1: "Attach a disk to D1:…",

--- a/apps/a8-web/src/messages.ts
+++ b/apps/a8-web/src/messages.ts
@@ -92,7 +92,7 @@ export const messages = {
 		machine: "Machine",
 		model: "Model",
 		ram: "RAM",
-		separateAntic: "Separate ANTIC",
+		separateAntic: "Separate ANTIC access",
 		tv: "TV",
 		basic: "BASIC",
 		on: "On",
@@ -127,9 +127,9 @@ export const messages = {
 
 	recents: {
 		title: "Recents",
-		keepTitle: "Keep in your library",
+		keepTitle: "Add to library",
 		remove: "Remove from recents",
-		kept: (name: string): string => `Kept ${name} in your library`,
+		kept: (name: string): string => `Added ${name} to the library`,
 	},
 
 	library: {
@@ -146,9 +146,9 @@ export const messages = {
 		deleted: (name: string): string => `Removed ${name}`,
 		confirmDelete: (name: string): string =>
 			`Delete ${name}? This can't be undone.`,
-		clear: "Clear your library",
+		clear: "Clear library",
 		confirmClear:
-			"Clear your entire library? This removes all your uploads and can't be undone.",
+			"Clear the entire library? This removes all uploads and can't be undone.",
 		cleared: "Library cleared",
 		actions: {
 			boot: "Boot",
@@ -198,7 +198,7 @@ export const messages = {
 			if (added > 0) {
 				parts.push(added === 1 ? "Added 1 image" : `Added ${added} images`);
 			}
-			if (deduped > 0) parts.push(`${deduped} already in your library`);
+			if (deduped > 0) parts.push(`${deduped} already in the library`);
 			if (failed > 0) {
 				parts.push(
 					failed === 1 ? "1 not recognized" : `${failed} not recognized`,
@@ -212,7 +212,7 @@ export const messages = {
 
 	reset: {
 		confirmEverything:
-			"Wipe your entire library AND all saved settings? This can't be undone.",
+			"Wipe the entire library AND all saved settings? This can't be undone.",
 		everything: "Reset everything — library and settings",
 		tab: "This tab reset to your saved settings",
 		defaults: "All settings reset to defaults",
@@ -250,7 +250,7 @@ export const messages = {
 		audioUnavailableReason: (reason: string) => `Audio unavailable: ${reason}`,
 		noWritableDisk: "No writable disk in D1: to download.",
 		noDiskToSave: "No disk in D1: to save.",
-		notLibraryDisk: "Only a disk attached from your library can be saved.",
+		notLibraryDisk: "Only a disk attached from the library can be saved.",
 		noDiskToDetach: "No disk in D1: to detach.",
 		notACartridge: "not a cartridge image",
 		noCartridge: "No cartridge to detach.",
@@ -275,7 +275,7 @@ export const messages = {
 		switchingTv: (tv: string) => `Switching TV to ${tv}`,
 		powerCycling: "Power cycling",
 		saving: (name: string) => `Saving (${name})`,
-		savedToLibrary: (name: string) => `Saved (${name}) to your library`,
+		savedToLibrary: (name: string) => `Saved (${name}) to the library`,
 		copy: "Copy",
 		copied: "Copied",
 		dismiss: "Dismiss",
@@ -301,7 +301,7 @@ export const labels = {
 	MENU_TOGGLE: "Menu",
 	OPEN_ROMS: "ROM preferences…",
 	OPEN_LIBRARY: "Library…",
-	CLEAR_LIBRARY: "Clear your library…",
+	CLEAR_LIBRARY: "Clear library…",
 	NUKE_EVERYTHING: "Reset everything: wipe library and settings…",
 	RESET_TAB_SETTINGS: "Reset this tab to saved settings",
 	RESET_DEFAULT_SETTINGS: "Reset all settings to defaults",
@@ -312,7 +312,7 @@ export const labels = {
 	ATTACH_CARTRIDGE: "Attach a cartridge… (reboots)",
 	DETACH_CARTRIDGE: "Detach the cartridge (reboots)",
 	DOWNLOAD_D1: "Download the D1: disk image…",
-	SAVE_D1_TO_LIBRARY: "Save D1: to your library",
+	SAVE_D1_TO_LIBRARY: "Save D1: to library",
 	SET_MODEL_400_800: "Set model to Atari 400/800 (reboots)",
 	SET_MODEL_1200XL: "Set model to Atari 1200XL (reboots)",
 	SET_MODEL_XLXE: "Set model to Atari XL/XE (reboots)",

--- a/apps/a8-web/src/messages.ts
+++ b/apps/a8-web/src/messages.ts
@@ -100,7 +100,6 @@ export const messages = {
 		rebootToApply: "Reboot to apply",
 		commandPalette: "Command palette…",
 		bootImage: "Boot image…",
-		software: "Software",
 		keys: "Keys",
 		about: "About",
 		aboutBlurb: "Sfotty Pie A8 Web — an Atari 8-bit emulator. MIT-licensed.",
@@ -124,6 +123,13 @@ export const messages = {
 		manageLibrary: "Manage library",
 		builtin: "Built-in",
 		yourRoms: "Your ROMs",
+	},
+
+	recents: {
+		title: "Recents",
+		keepTitle: "Keep in your library",
+		remove: "Remove from recents",
+		kept: (name: string): string => `Kept ${name} in your library`,
 	},
 
 	library: {

--- a/apps/a8-web/src/persist.ts
+++ b/apps/a8-web/src/persist.ts
@@ -1,0 +1,68 @@
+import { storageName } from "./storage.ts";
+
+// Per-tab-stable persisted state. Reads sessionStorage (this tab's value, which
+// survives its own reload) first, falling back to the localStorage "last used"
+// seed a fresh tab inherits; writes update both. So multiple tabs never
+// cross-clobber the running machine — each is stable across its own reloads, and
+// a new tab inherits the most recent setup. Resilient: storage being
+// unavailable (private mode, quota, disabled) just means no persistence.
+
+/** Read a persisted JSON value, or `undefined` if absent/unparsable. */
+export function loadPersisted(key: string): unknown {
+	const name = storageName(key);
+	let raw: string | null;
+	try {
+		raw = sessionStorage.getItem(name) ?? localStorage.getItem(name);
+	} catch {
+		return undefined;
+	}
+	if (raw === null) return undefined;
+	try {
+		return JSON.parse(raw);
+	} catch {
+		return undefined;
+	}
+}
+
+/** Persist a JSON value to this tab (sessionStorage) and the seed (localStorage). */
+export function savePersisted(key: string, value: unknown): void {
+	const name = storageName(key);
+	try {
+		const raw = JSON.stringify(value);
+		sessionStorage.setItem(name, raw);
+		localStorage.setItem(name, raw);
+	} catch {
+		// Storage unavailable or full — run without persistence this session.
+	}
+}
+
+// Remove every `a8.*`-namespaced key from a storage area (leaves other sites'
+// keys alone).
+function clearArea(area: Storage): void {
+	const prefix = storageName("");
+	const keys: string[] = [];
+	for (let i = 0; i < area.length; i++) {
+		const key = area.key(i);
+		if (key !== null && key.startsWith(prefix)) keys.push(key);
+	}
+	for (const key of keys) area.removeItem(key);
+}
+
+/** Drop this tab's overrides (sessionStorage), reverting to the saved seed. */
+export function clearSessionPersisted(): void {
+	try {
+		clearArea(sessionStorage);
+	} catch {
+		// unavailable
+	}
+}
+
+/** Drop all persisted state — this tab's and the saved seed (both stores). */
+export function clearAllPersisted(): void {
+	try {
+		clearArea(sessionStorage);
+		clearArea(localStorage);
+	} catch {
+		// unavailable
+	}
+}

--- a/apps/a8-web/src/persist.ts
+++ b/apps/a8-web/src/persist.ts
@@ -55,6 +55,25 @@ export function saveSession(key: string, value: unknown): void {
 	}
 }
 
+/** Read a value shared across all tabs (localStorage only). */
+export function loadLocal(key: string): unknown {
+	try {
+		const raw = localStorage.getItem(storageName(key));
+		return raw === null ? undefined : JSON.parse(raw);
+	} catch {
+		return undefined;
+	}
+}
+
+/** Persist a value shared across all tabs (localStorage only). */
+export function saveLocal(key: string, value: unknown): void {
+	try {
+		localStorage.setItem(storageName(key), JSON.stringify(value));
+	} catch {
+		// Storage unavailable or full — run without persistence this session.
+	}
+}
+
 // Remove every `a8.*`-namespaced key from a storage area (leaves other sites'
 // keys alone).
 function clearArea(area: Storage): void {

--- a/apps/a8-web/src/persist.ts
+++ b/apps/a8-web/src/persist.ts
@@ -36,6 +36,25 @@ export function savePersisted(key: string, value: unknown): void {
 	}
 }
 
+/** Read a value from this tab's session only — no cross-tab seed fallback. */
+export function loadSession(key: string): unknown {
+	try {
+		const raw = sessionStorage.getItem(storageName(key));
+		return raw === null ? undefined : JSON.parse(raw);
+	} catch {
+		return undefined;
+	}
+}
+
+/** Persist a value to this tab's session only (not the cross-tab seed). */
+export function saveSession(key: string, value: unknown): void {
+	try {
+		sessionStorage.setItem(storageName(key), JSON.stringify(value));
+	} catch {
+		// Storage unavailable or full — run without persistence this session.
+	}
+}
+
 // Remove every `a8.*`-namespaced key from a storage area (leaves other sites'
 // keys alone).
 function clearArea(area: Storage): void {

--- a/apps/a8-web/src/recents.ts
+++ b/apps/a8-web/src/recents.ts
@@ -1,0 +1,66 @@
+// The recently-booted images, newest first — a global (cross-tab) history kept
+// in localStorage, capped. Entries are unified library ids; they're resolved
+// against the library when rendered, skipping any that no longer exist. The
+// menu's "Recents" section is this history followed by the built-in software
+// you haven't booted, so it's never empty.
+
+import { computed, signal } from "@preact/signals";
+import { builtinSoftware, getImage } from "./images/library.ts";
+import type { ImageEntry } from "./images/metadata.ts";
+import { loadLocal, saveLocal } from "./persist.ts";
+
+const RECENTS_KEY = "recents";
+export const RECENTS_CAP = 10;
+
+function load(): string[] {
+	const raw = loadLocal(RECENTS_KEY);
+	if (!Array.isArray(raw)) return [];
+	return raw
+		.filter((x): x is string => typeof x === "string")
+		.slice(0, RECENTS_CAP);
+}
+
+/** The MRU history (unified ids, newest first). */
+export const recentIds = signal<string[]>(load());
+
+/** Mark an image as just-used: move it to the front, dedup, cap, persist. */
+export function touchRecent(id: string): void {
+	const next = [id, ...recentIds.value.filter((x) => x !== id)].slice(
+		0,
+		RECENTS_CAP,
+	);
+	recentIds.value = next;
+	saveLocal(RECENTS_KEY, next);
+}
+
+/** Drop an image from the recents history (persisted). */
+export function removeRecent(id: string): void {
+	if (!recentIds.value.includes(id)) return;
+	const next = recentIds.value.filter((x) => x !== id);
+	recentIds.value = next;
+	saveLocal(RECENTS_KEY, next);
+}
+
+/** A recents row: the resolved entry, and whether it's in the MRU history. */
+export interface RecentItem {
+	entry: ImageEntry;
+	/** In the MRU history (vs an appended, not-yet-booted built-in). */
+	recent: boolean;
+}
+
+/**
+ * The menu's recents view: the MRU history (resolved, newest first) followed by
+ * built-in software not already in it (alphabetical). Stale ids are skipped.
+ */
+export const recentsView = computed<RecentItem[]>(() => {
+	const ids = recentIds.value;
+	const mru: RecentItem[] = ids
+		.map((id) => getImage(id))
+		.filter((e): e is ImageEntry => e !== undefined)
+		.map((entry) => ({ entry, recent: true }));
+	const inMru = new Set(ids);
+	const seeds: RecentItem[] = builtinSoftware.value
+		.filter((e) => !inMru.has(e.id))
+		.map((entry) => ({ entry, recent: false }));
+	return [...mru, ...seeds];
+});

--- a/apps/a8-web/src/routes/a8/emu/library.page.tsx
+++ b/apps/a8-web/src/routes/a8/emu/library.page.tsx
@@ -148,8 +148,11 @@ export default function LibraryPage() {
 			: "";
 	const query = params.q.trim().toLowerCase();
 
-	const entries = libraryEntries.value;
-	const hasUploads = entries.some((entry) => entry.source === "user");
+	// Auto-added (transient) images are hidden from the curated list; recents
+	// surface them later.
+	const allEntries = libraryEntries.value;
+	const entries = allEntries.filter((entry) => !entry.transient);
+	const hasUploads = allEntries.some((entry) => entry.source === "user");
 
 	// Sort once per (entries, key, dir); filtering below preserves order, so
 	// typing in the filter never re-sorts.

--- a/apps/a8-web/src/routes/a8/emu/roms.page.tsx
+++ b/apps/a8-web/src/routes/a8/emu/roms.page.tsx
@@ -274,16 +274,13 @@ export default function RomsPage() {
 							: messages.roms.save}
 					</button>
 				)}
-				<div class="flex items-baseline justify-between gap-2">
-					<p class="text-xs text-neutral-400">{messages.roms.picksReset}</p>
-					<button
-						type="button"
-						class="shrink-0 text-xs text-neutral-500 hover:underline"
-						onClick={() => host.showPanel("library")}
-					>
-						{messages.roms.manageLibrary} →
-					</button>
-				</div>
+				<button
+					type="button"
+					class="self-end text-xs text-neutral-500 hover:underline"
+					onClick={() => host.showPanel("library")}
+				>
+					{messages.roms.manageLibrary} →
+				</button>
 			</div>
 		</PanelFrame>
 	);

--- a/apps/a8-web/src/sidebar.tsx
+++ b/apps/a8-web/src/sidebar.tsx
@@ -1,5 +1,6 @@
 import type { EmulatorHost } from "./host.ts";
-import { builtinLibrary } from "./library.ts";
+import { Icon } from "./icon.tsx";
+import type { ImageType } from "./images/metadata.ts";
 import {
 	anticPolicy,
 	MODELS,
@@ -9,10 +10,7 @@ import {
 	type AtariModel,
 } from "./machine-config.ts";
 import { messages } from "./messages.ts";
-
-// The bootable software in the library (the firmware/ items are auto-selected
-// by the host, not listed here).
-const software = builtinLibrary.filter((entry) => entry.category === "other");
+import { recentsView } from "./recents.ts";
 
 /**
  * The chord that opens the command palette: Cmd+K on macOS, Alt+K elsewhere.
@@ -102,6 +100,85 @@ function KeyRow({ keys, action }: { keys: string; action: string }) {
 			<dt class="whitespace-nowrap text-neutral-500">{keys}</dt>
 			<dd>{action}</dd>
 		</>
+	);
+}
+
+// Per-type leading pill: a three-letter format code — monospace so they align
+// into a column — tinted by kind. disk → atr, cart → car, xex → xex, os → rom.
+const TYPE_PILL: Record<ImageType, { code: string; tint: string }> = {
+	disk: { code: "atr", tint: "bg-sky-100 text-sky-700" },
+	cart: { code: "car", tint: "bg-amber-100 text-amber-700" },
+	xex: { code: "xex", tint: "bg-emerald-100 text-emerald-700" },
+	os: { code: "rom", tint: "bg-violet-100 text-violet-700" },
+};
+
+/** The leading type pill for a recents row; the full type name is its tooltip. */
+function TypePill({ type }: { type: ImageType }) {
+	const { code, tint } = TYPE_PILL[type];
+	return (
+		<span
+			class={`shrink-0 rounded px-1.5 py-0.5 font-mono text-[10px] leading-none ${tint}`}
+			title={messages.library.typeName[type]}
+		>
+			{code}
+		</span>
+	);
+}
+
+/**
+ * The recents list: images you've booted (newest first), then the built-in
+ * software you haven't, so it's never empty. Click to boot; a transient
+ * (file-booted) item can be kept in the library, and any history item removed.
+ */
+function RecentsSection({ host }: { host: EmulatorHost }) {
+	const items = recentsView.value;
+	if (items.length === 0) return null;
+	return (
+		<section>
+			<h2 class="mb-2 text-xs font-semibold tracking-wide text-neutral-500 uppercase">
+				{messages.recents.title}
+			</h2>
+			<ul class="flex flex-col gap-1">
+				{items.map(({ entry, recent }) => (
+					<li
+						key={entry.id}
+						class="flex items-center gap-2 rounded px-1.5 py-1 transition-colors duration-150 hover:bg-neutral-100"
+					>
+						<TypePill type={entry.derived.type} />
+						<button
+							type="button"
+							class="min-w-0 flex-1 truncate text-left text-sm hover:underline"
+							title={entry.user.displayName}
+							onClick={() => void host.bootImage(entry.id)}
+						>
+							{entry.user.displayName}
+						</button>
+						{entry.transient && (
+							<button
+								type="button"
+								class="shrink-0 text-neutral-400 hover:text-neutral-700"
+								title={messages.recents.keepTitle}
+								aria-label={messages.recents.keepTitle}
+								onClick={() => host.keepRecent(entry.id)}
+							>
+								<Icon name="bookmark" class="size-4" />
+							</button>
+						)}
+						{recent && (
+							<button
+								type="button"
+								class="shrink-0 text-neutral-400 hover:text-neutral-700"
+								title={messages.recents.remove}
+								aria-label={messages.recents.remove}
+								onClick={() => host.removeFromRecents(entry.id)}
+							>
+								<Icon name="close" class="size-4" />
+							</button>
+						)}
+					</li>
+				))}
+			</ul>
+		</section>
 	);
 }
 
@@ -241,26 +318,7 @@ export function MenuView({
 				</button>
 			</section>
 
-			{software.length > 0 && (
-				<section>
-					<h2 class="mb-2 text-xs font-semibold tracking-wide text-neutral-500 uppercase">
-						{messages.sidebar.software}
-					</h2>
-					<ul class="flex flex-col gap-1">
-						{software.map((entry) => (
-							<li key={entry.id}>
-								<button
-									type="button"
-									class="text-left text-sm hover:underline"
-									onClick={() => void host.bootLibraryEntry(entry)}
-								>
-									{entry.displayName}
-								</button>
-							</li>
-						))}
-					</ul>
-				</section>
-			)}
+			<RecentsSection host={host} />
 
 			{/* The key-mappings help is moot without a physical keyboard. Gate
 			    on pointer capability, not width: a phone in landscape is wide


### PR DESCRIPTION
Persists the emulator's working state across reloads and adds a Recents menu, building on the image library from #27.

## What's in it

- **Config + ROM persistence** (`ef5eb6a`) — machine config (model/RAM/TV/BASIC) and firmware picks survive reloads via a sessionStorage-first / localStorage-seed cascade, so each tab is stable across its own reloads while a fresh tab inherits the last-used setup. Adds testing/reset palette commands (nuke everything, reset-to-saved, reset-to-defaults) that reboot only when they have to.
- **File boots routed through the library** (`c4a08ef`) — booting/attaching a file from the picker now auto-adds it as a `transient` library entry, so it has an id (for resume + save) and a content hash (for dedup). Hidden from the curated library view.
- **Mounted-media resume** (`9603a41`) — the cartridge slot and D1: disk (file-booted, attached, or library-picked, incl. XEX) re-mount on a same-tab reload with the live BASIC state. New tabs start fresh (media is sessionStorage-only — no surprise auto-boot). Stale ids resolve to empty slots gracefully.
- **Recents menu** (`f8732e6`) — replaces the static Software section with a global MRU (cap 10) of booted images, seeded with the built-in software. Per row: boot on click, Keep (promote a transient into the curated library), and remove. A boot-triggered sweep trims transients that fall off recents (keeping anything still mounted). Type shown as a monospace colour-coded pill (atr/car/xex).

## Known gaps (deferred, noted)

- **GC backstop** — blobs are reclaimed by eager refcounting at deletion points; a blob orphaned by an interrupted write has no sweep, and the transient sweep is boot-triggered only. A one-shot `readyLibrary` reconcile would close it.
- **Cross-tab races** — the shared IndexedDB library has no cross-tab coordination; concurrent mutations from two tabs can race the in-memory refcount. Single-tab use assumed for now.

All green: lint, typecheck, unit, build.