### PR TITLE
a8-web: library view rework — pills, per-type tables, filtering, item details

### DIFF
--- a/apps/a8-web/src/messages.ts
+++ b/apps/a8-web/src/messages.ts
@@ -185,7 +185,7 @@ export const messages = {
 		// Per-type fact rows in the item detail view.
 		fields: {
 			cartType: "Cartridge type",
-			sizeClass: "Size class",
+			osType: "OS type",
 			sectors: "Sectors",
 			sectorSize: "Sector size",
 		},

--- a/apps/a8-web/src/messages.ts
+++ b/apps/a8-web/src/messages.ts
@@ -182,6 +182,13 @@ export const messages = {
 			bps: "BPS",
 		},
 		removeFilter: "Remove filter",
+		// Per-type fact rows in the item detail view.
+		fields: {
+			cartType: "Cartridge type",
+			sizeClass: "Size class",
+			sectors: "Sectors",
+			sectorSize: "Sector size",
+		},
 		typeName: {
 			os: "OS",
 			cart: "Cartridge",

--- a/apps/a8-web/src/messages.ts
+++ b/apps/a8-web/src/messages.ts
@@ -189,6 +189,8 @@ export const messages = {
 			sectors: "Sectors",
 			sectorSize: "Sector size",
 		},
+		// Heading for the item view's recognized-firmware section.
+		firmwareTitle: "Well-known firmware",
 		typeName: {
 			os: "OS",
 			cart: "Cartridge",

--- a/apps/a8-web/src/messages.ts
+++ b/apps/a8-web/src/messages.ts
@@ -175,9 +175,13 @@ export const messages = {
 			source: "Source",
 		},
 		// Extra table head for a type-filtered disk view — sectors×bytes-per-sector.
+		// `sectors`/`bps` label the dismissable filter chips for each part.
 		detail: {
 			geometry: "Geometry",
+			sectors: "sectors",
+			bps: "BPS",
 		},
+		removeFilter: "Remove filter",
 		typeName: {
 			os: "OS",
 			cart: "Cartridge",

--- a/apps/a8-web/src/messages.ts
+++ b/apps/a8-web/src/messages.ts
@@ -167,24 +167,22 @@ export const messages = {
 		sourceUser: "Yours",
 		prev: "Prev",
 		next: "Next",
+		// Field labels — filter selects, the item detail view, and table heads.
 		columns: {
 			name: "Name",
 			type: "Type",
 			size: "Size",
 			source: "Source",
 		},
+		// Extra table head for a type-filtered disk view — sectors×bytes-per-sector.
+		detail: {
+			geometry: "Geometry",
+		},
 		typeName: {
 			os: "OS",
 			cart: "Cartridge",
 			disk: "Disk",
 			xex: "Executable",
-		},
-		// Compact forms for the dense table column.
-		typeShort: {
-			os: "os",
-			cart: "cart",
-			disk: "disk",
-			xex: "exe",
 		},
 		range: (from: number, to: number, total: number): string =>
 			`${from}–${to} of ${total}`,

--- a/apps/a8-web/src/routes/a8/emu/library-item.page.tsx
+++ b/apps/a8-web/src/routes/a8/emu/library-item.page.tsx
@@ -1,4 +1,4 @@
-import { canonicalize } from "@sfotty-pie/a8";
+import { canonicalize, CART_TYPES } from "@sfotty-pie/a8";
 import { useEffect, useState } from "preact/hooks";
 import {
 	getImage,
@@ -31,19 +31,28 @@ const CANON_EXT: Record<ImageType, string> = {
 	xex: "xex",
 };
 
-// The type plus its one discriminating fact, e.g. "Cartridge · CART 1".
-function typeDetail(entry: ImageEntry): string {
-	const name = messages.library.typeName;
-	const derived = entry.derived;
-	switch (derived.type) {
+// The per-type facts, each its own detail row (the kind itself is a separate
+// "Type" row). A cartridge resolves to its full CART_TYPES name; xex has none.
+function detailRows(entry: ImageEntry): { label: string; value: string }[] {
+	const f = messages.library.fields;
+	const k = entry.derived;
+	switch (k.type) {
 		case "os":
-			return `${name.os} · ${derived.sizeClass}K`;
+			return [{ label: f.sizeClass, value: `${k.sizeClass}K` }];
 		case "cart":
-			return `${name.cart} · CART ${derived.cartType}`;
+			return [
+				{
+					label: f.cartType,
+					value: CART_TYPES[k.cartType]?.name ?? `CART ${k.cartType}`,
+				},
+			];
 		case "disk":
-			return `${name.disk} · ${derived.sectorSize}B × ${derived.sectors}`;
+			return [
+				{ label: f.sectors, value: String(k.sectors) },
+				{ label: f.sectorSize, value: `${k.sectorSize} B` },
+			];
 		case "xex":
-			return name.xex;
+			return [];
 	}
 }
 
@@ -153,8 +162,11 @@ export default function LibraryItemPanel({ id: rawId }: { id: string }) {
 					/>
 					<Detail
 						label={messages.library.columns.type}
-						value={typeDetail(entry)}
+						value={messages.library.typeName[entry.derived.type]}
 					/>
+					{detailRows(entry).map((d) => (
+						<Detail key={d.label} label={d.label} value={d.value} />
+					))}
 					<Detail
 						label={messages.library.columns.size}
 						value={sizeLabel(entry.size)}

--- a/apps/a8-web/src/routes/a8/emu/library-item.page.tsx
+++ b/apps/a8-web/src/routes/a8/emu/library-item.page.tsx
@@ -1,4 +1,9 @@
-import { canonicalize, CART_TYPES } from "@sfotty-pie/a8";
+import {
+	canonicalize,
+	CART_TYPES,
+	detectFirmware,
+	type FirmwareInfo,
+} from "@sfotty-pie/a8";
 import { useEffect, useState } from "preact/hooks";
 import {
 	getImage,
@@ -19,6 +24,18 @@ const LIBRARY = "/a8/emu/library";
 
 function sizeLabel(bytes: number): string {
 	return `${Math.round(bytes / 1024)}K`;
+}
+
+// A canonical cartridge blob is a 16-byte CART header + the raw ROM; firmware
+// detection wants the unwrapped ROM (built-ins already serve it raw).
+function isCar(bytes: Uint8Array): boolean {
+	return (
+		bytes.length > 16 &&
+		bytes[0] === 0x43 && // C
+		bytes[1] === 0x41 && // A
+		bytes[2] === 0x52 && // R
+		bytes[3] === 0x54 // T
+	);
 }
 
 // Canonical download extension per type: a cartridge is a `.car`, an OS a raw
@@ -90,6 +107,32 @@ export default function LibraryItemPanel({ id: rawId }: { id: string }) {
 	} catch {
 		/* keep the raw id if it isn't valid percent-encoding */
 	}
+
+	// Detect well-known firmware from the bytes — only OS/cartridge images can
+	// be one, so other types skip the (potentially large) read.
+	const [firmware, setFirmware] = useState<FirmwareInfo | null>(null);
+	useEffect(() => {
+		let cancelled = false;
+		void (async () => {
+			try {
+				await readyLibrary();
+				const e = getImage(id);
+				if (e?.derived.type !== "os" && e?.derived.type !== "cart") {
+					if (!cancelled) setFirmware(null);
+					return;
+				}
+				const bytes = await getImageBytes(id);
+				const rom = isCar(bytes) ? bytes.subarray(16) : bytes;
+				if (!cancelled) setFirmware(detectFirmware(rom));
+			} catch {
+				if (!cancelled) setFirmware(null);
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, [id]);
+
 	const entry = getImage(id); // reactive on the merged library
 
 	if (!entry) {
@@ -231,6 +274,19 @@ export default function LibraryItemPanel({ id: rawId }: { id: string }) {
 						</button>
 					)}
 				</div>
+
+				{firmware && (
+					<div class="flex flex-col gap-1 border-t border-neutral-200 pt-3">
+						<h3 class="text-xs font-semibold tracking-wide text-neutral-500 uppercase">
+							{messages.library.firmwareTitle}
+						</h3>
+						<p class="text-sm font-medium text-neutral-800">{firmware.name}</p>
+						<p class="text-xs text-neutral-500">{firmware.origin}</p>
+						{firmware.notes && (
+							<p class="text-xs text-neutral-500">{firmware.notes}</p>
+						)}
+					</div>
+				)}
 			</div>
 		</PanelFrame>
 	);

--- a/apps/a8-web/src/routes/a8/emu/library-item.page.tsx
+++ b/apps/a8-web/src/routes/a8/emu/library-item.page.tsx
@@ -26,6 +26,12 @@ function sizeLabel(bytes: number): string {
 	return `${Math.round(bytes / 1024)}K`;
 }
 
+// An OS ROM's target machine family, from its size class (10K → 400/800,
+// 16K → the XL/XE class). Hardware tokens, kept inline.
+function osTypeLabel(sizeClass: number): string {
+	return sizeClass === 10 ? "400/800" : "XL/XE";
+}
+
 // A canonical cartridge blob is a 16-byte CART header + the raw ROM; firmware
 // detection wants the unwrapped ROM (built-ins already serve it raw).
 function isCar(bytes: Uint8Array): boolean {
@@ -55,7 +61,7 @@ function detailRows(entry: ImageEntry): { label: string; value: string }[] {
 	const k = entry.derived;
 	switch (k.type) {
 		case "os":
-			return [{ label: f.sizeClass, value: `${k.sizeClass}K` }];
+			return [{ label: f.osType, value: osTypeLabel(k.sizeClass) }];
 		case "cart":
 			return [
 				{

--- a/apps/a8-web/src/routes/a8/emu/library.page.tsx
+++ b/apps/a8-web/src/routes/a8/emu/library.page.tsx
@@ -5,9 +5,10 @@ import {
 	libraryEntries,
 	readyLibrary,
 } from "../../../images/library.ts";
-import type { ImageEntry, ImageType } from "../../../images/metadata.ts";
+import type { DerivedMeta, ImageType } from "../../../images/metadata.ts";
 import { messages } from "../../../messages.ts";
 import { navigate } from "../../../navigate.ts";
+import { TypePill } from "../../../type-pill.tsx";
 import { useUrlParams } from "../../../url-params.ts";
 import { useEmu } from "./emu-context.ts";
 import { PanelFrame } from "./panel-frame.tsx";
@@ -22,9 +23,50 @@ import { PanelFrame } from "./panel-frame.tsx";
 
 const PAGE_SIZE = 100;
 
-type SortKey = "name" | "type";
-const SORT_KEYS: readonly SortKey[] = ["name", "type"];
 const TYPE_VALUES: readonly ImageType[] = ["os", "cart", "disk", "xex"];
+
+interface DetailCol {
+	head: string;
+	width: string;
+	cell: (kind: DerivedMeta) => string;
+}
+
+// The extra table columns for a type-filtered view (the pill is dropped — the
+// type is known from the filter): OS size class, cartridge subtype, disk
+// geometry split into sectors + sector size. xex has no extra facts. Each cell
+// guards on the kind, though the active filter guarantees it. Values are inline
+// tokens (hardware/numeric), per messages.ts.
+function detailCols(type: ImageType): DetailCol[] {
+	switch (type) {
+		case "os":
+			return [
+				{
+					head: messages.library.columns.size,
+					width: "w-14",
+					cell: (k) => (k.type === "os" ? `${k.sizeClass}K` : ""),
+				},
+			];
+		case "cart":
+			return [
+				{
+					head: messages.library.columns.type,
+					width: "w-14",
+					cell: (k) => (k.type === "cart" ? String(k.cartType) : ""),
+				},
+			];
+		case "disk":
+			return [
+				{
+					head: messages.library.detail.geometry,
+					width: "w-24",
+					cell: (k) =>
+						k.type === "disk" ? `${k.sectors}×${k.sectorSize}` : "",
+				},
+			];
+		case "xex":
+			return [];
+	}
+}
 
 // Read a directory reader's entries — it returns them in batches, so call until
 // it yields none.
@@ -66,19 +108,6 @@ async function filesFromDrop(transfer: DataTransfer): Promise<File[]> {
 	return out;
 }
 
-// Compare by the chosen key, then by name as a stable tiebreak.
-function comparator(key: SortKey): (a: ImageEntry, b: ImageEntry) => number {
-	const byName = (a: ImageEntry, b: ImageEntry) =>
-		a.user.displayName.localeCompare(b.user.displayName);
-	switch (key) {
-		case "name":
-			return byName;
-		case "type":
-			return (a, b) =>
-				a.derived.type.localeCompare(b.derived.type) || byName(a, b);
-	}
-}
-
 export default function LibraryPage() {
 	const { host } = useEmu();
 	const inputRef = useRef<HTMLInputElement>(null);
@@ -90,14 +119,7 @@ export default function LibraryPage() {
 	useEffect(() => {
 		if (folderInputRef.current) folderInputRef.current.webkitdirectory = true;
 	}, []);
-	const [params, setParams] = useUrlParams([
-		"q",
-		"type",
-		"source",
-		"sort",
-		"dir",
-		"page",
-	]);
+	const [params, setParams] = useUrlParams(["q", "type", "source", "page"]);
 
 	// Pull the user's uploads into the merged list (built-ins are already there).
 	useEffect(() => void readyLibrary(), []);
@@ -135,10 +157,6 @@ export default function LibraryPage() {
 	};
 
 	// Read view state from the URL, ignoring anything malformed.
-	const sortKey: SortKey = SORT_KEYS.includes(params.sort as SortKey)
-		? (params.sort as SortKey)
-		: "name";
-	const desc = params.dir === "desc";
 	const typeFilter = TYPE_VALUES.includes(params.type as ImageType)
 		? (params.type as ImageType)
 		: "";
@@ -154,13 +172,15 @@ export default function LibraryPage() {
 	const entries = allEntries.filter((entry) => !entry.transient);
 	const hasUploads = allEntries.some((entry) => entry.source === "user");
 
-	// Sort once per (entries, key, dir); filtering below preserves order, so
-	// typing in the filter never re-sorts.
-	const sorted = useMemo(() => {
-		const cmp = comparator(sortKey);
-		const arr = [...entries].sort(cmp);
-		return desc ? arr.reverse() : arr;
-	}, [entries, sortKey, desc]);
+	// Fixed alphabetical order (sorting was dropped — direction wasn't
+	// meaningful); filtering below preserves order, so typing never re-sorts.
+	const sorted = useMemo(
+		() =>
+			[...entries].sort((a, b) =>
+				a.user.displayName.localeCompare(b.user.displayName),
+			),
+		[entries],
+	);
 
 	const filtered = sorted.filter(
 		(e) =>
@@ -175,33 +195,12 @@ export default function LibraryPage() {
 	const start = (page - 1) * PAGE_SIZE;
 	const rows = filtered.slice(start, start + PAGE_SIZE);
 
-	const toggleSort = (key: SortKey): void => {
-		const nextDesc = key === sortKey ? !desc : false;
-		setParams({ sort: key, dir: nextDesc ? "desc" : null, page: null });
-	};
 	const goToPage = (next: number): void =>
 		setParams({ page: next > 1 ? String(next) : null });
 
-	const sortHeader = (
-		key: SortKey,
-		label: string,
-		cls = "",
-	): preact.JSX.Element => (
-		<th class={`px-2 py-1.5 font-medium ${cls}`}>
-			<button
-				type="button"
-				class="inline-flex items-center gap-1 hover:text-neutral-800"
-				onClick={() => toggleSort(key)}
-			>
-				{label}
-				{sortKey === key && (
-					<span aria-hidden class="text-[9px]">
-						{desc ? "▼" : "▲"}
-					</span>
-				)}
-			</button>
-		</th>
-	);
+	// All-types is a flat list with leading type pills; a type-filtered view is a
+	// table whose extra columns carry that type's attributes.
+	const cols = typeFilter === "" ? [] : detailCols(typeFilter);
 
 	return (
 		<PanelFrame title={messages.library.title}>
@@ -318,12 +317,43 @@ export default function LibraryPage() {
 
 				{total === 0 ? (
 					<p class="text-sm text-neutral-400">{messages.library.noMatches}</p>
+				) : typeFilter === "" ? (
+					<ul class="flex flex-col text-sm">
+						{rows.map((entry) => (
+							<li key={entry.id}>
+								<button
+									type="button"
+									class="flex w-full items-center gap-2 rounded px-1.5 py-1 text-left hover:bg-neutral-100"
+									onClick={() =>
+										navigate(`/a8/emu/library/${encodeURIComponent(entry.id)}`)
+									}
+								>
+									<TypePill type={entry.derived.type} />
+									<span
+										class="min-w-0 flex-1 truncate text-neutral-800"
+										title={entry.user.displayName}
+									>
+										{entry.user.displayName}
+									</span>
+								</button>
+							</li>
+						))}
+					</ul>
 				) : (
 					<table class="w-full table-fixed border-collapse text-sm">
 						<thead class="border-b border-neutral-200 text-left text-xs tracking-wide text-neutral-500 uppercase">
 							<tr>
-								{sortHeader("name", messages.library.columns.name)}
-								{sortHeader("type", messages.library.columns.type, "w-16")}
+								<th class="px-2 py-1.5 font-medium">
+									{messages.library.columns.name}
+								</th>
+								{cols.map((c) => (
+									<th
+										key={c.head}
+										class={`px-2 py-1.5 text-right font-medium ${c.width}`}
+									>
+										{c.head}
+									</th>
+								))}
 							</tr>
 						</thead>
 						<tbody>
@@ -342,9 +372,14 @@ export default function LibraryPage() {
 											{entry.user.displayName}
 										</button>
 									</td>
-									<td class="px-2 py-1 text-neutral-500">
-										{messages.library.typeShort[entry.derived.type]}
-									</td>
+									{cols.map((c) => (
+										<td
+											key={c.head}
+											class="px-2 py-1 text-right tabular-nums text-neutral-500"
+										>
+											{c.cell(entry.derived)}
+										</td>
+									))}
 								</tr>
 							))}
 						</tbody>

--- a/apps/a8-web/src/routes/a8/emu/library.page.tsx
+++ b/apps/a8-web/src/routes/a8/emu/library.page.tsx
@@ -27,10 +27,21 @@ const PAGE_SIZE = 100;
 
 const TYPE_VALUES: readonly ImageType[] = ["os", "cart", "disk", "xex"];
 
+// An OS ROM's target machine family: the stored size class (10K → 400/800,
+// 16K → the XL/XE class) maps to a URL-clean slug and a display label, so the
+// query param reads like the UI. Hardware tokens, kept inline.
+const OS_FAMILY = {
+	"400-800": { sizeClass: 10, label: "400/800" },
+	"xl-xe": { sizeClass: 16, label: "XL/XE" },
+} as const;
+type OsFamily = keyof typeof OS_FAMILY;
+const osFamilyOf = (sizeClass: number): OsFamily =>
+	sizeClass === 10 ? "400-800" : "xl-xe";
+
 // The attribute filters a detail value can set (URL params); only meaningful
 // within the matching type-filtered view.
-type AttrParam = "sizeClass" | "cartType" | "sectors" | "bps";
-type SetAttr = (param: AttrParam, value: number) => void;
+type AttrParam = "os" | "cartType" | "sectors" | "bps";
+type SetAttr = (param: AttrParam, value: number | string) => void;
 
 // A clickable detail value: sets an attribute filter; underlines on hover.
 function FilterValue({
@@ -67,13 +78,13 @@ function detailCols(type: ImageType): DetailCol[] {
 		case "os":
 			return [
 				{
-					head: messages.library.columns.size,
-					width: "w-14",
+					head: messages.library.columns.type,
+					width: "w-20",
 					render: (k, set) =>
 						k.type === "os" ? (
 							<FilterValue
-								value={`${k.sizeClass}K`}
-								onClick={() => set("sizeClass", k.sizeClass)}
+								value={OS_FAMILY[osFamilyOf(k.sizeClass)].label}
+								onClick={() => set("os", osFamilyOf(k.sizeClass))}
 							/>
 						) : (
 							<></>
@@ -180,7 +191,7 @@ export default function LibraryPage() {
 		"type",
 		"source",
 		"page",
-		"sizeClass",
+		"os",
 		"cartType",
 		"sectors",
 		"bps",
@@ -263,8 +274,8 @@ export default function LibraryPage() {
 			return false;
 		// Attribute filters — apply only to entries of the matching kind.
 		const k = e.derived;
-		if (params.sizeClass && k.type === "os")
-			return String(k.sizeClass) === params.sizeClass;
+		if (params.os && k.type === "os")
+			return osFamilyOf(k.sizeClass) === params.os;
 		if (params.cartType && k.type === "cart")
 			return String(k.cartType) === params.cartType;
 		if (k.type === "disk") {
@@ -289,8 +300,11 @@ export default function LibraryPage() {
 
 	// Active attribute filters, as dismissable chips (only the current type's).
 	const attrFilters: { param: AttrParam; label: string }[] = [];
-	if (typeFilter === "os" && params.sizeClass)
-		attrFilters.push({ param: "sizeClass", label: `${params.sizeClass}K` });
+	if (typeFilter === "os" && params.os)
+		attrFilters.push({
+			param: "os",
+			label: OS_FAMILY[params.os as OsFamily]?.label ?? params.os,
+		});
 	if (typeFilter === "cart" && params.cartType)
 		attrFilters.push({
 			param: "cartType",
@@ -394,7 +408,7 @@ export default function LibraryPage() {
 								setParams({
 									type: event.currentTarget.value || null,
 									page: null,
-									sizeClass: null,
+									os: null,
 									cartType: null,
 									sectors: null,
 									bps: null,

--- a/apps/a8-web/src/routes/a8/emu/library.page.tsx
+++ b/apps/a8-web/src/routes/a8/emu/library.page.tsx
@@ -1,4 +1,6 @@
+import type { VNode } from "preact";
 import { useEffect, useMemo, useRef, useState } from "preact/hooks";
+import { Icon } from "../../../icon.tsx";
 import {
 	addFiles,
 	importProgress,
@@ -25,17 +27,41 @@ const PAGE_SIZE = 100;
 
 const TYPE_VALUES: readonly ImageType[] = ["os", "cart", "disk", "xex"];
 
+// The attribute filters a detail value can set (URL params); only meaningful
+// within the matching type-filtered view.
+type AttrParam = "sizeClass" | "cartType" | "sectors" | "bps";
+type SetAttr = (param: AttrParam, value: number) => void;
+
+// A clickable detail value: sets an attribute filter; underlines on hover.
+function FilterValue({
+	value,
+	onClick,
+}: {
+	value: number | string;
+	onClick: () => void;
+}) {
+	return (
+		<button
+			type="button"
+			class="cursor-pointer hover:underline"
+			onClick={onClick}
+		>
+			{value}
+		</button>
+	);
+}
+
 interface DetailCol {
 	head: string;
 	width: string;
-	cell: (kind: DerivedMeta) => string;
+	render: (kind: DerivedMeta, set: SetAttr) => VNode;
 }
 
 // The extra table columns for a type-filtered view (the pill is dropped — the
 // type is known from the filter): OS size class, cartridge subtype, disk
-// geometry split into sectors + sector size. xex has no extra facts. Each cell
-// guards on the kind, though the active filter guarantees it. Values are inline
-// tokens (hardware/numeric), per messages.ts.
+// geometry (sectors × bytes-per-sector, each clickable). Clicking a value sets
+// that attribute filter. Each render guards on the kind, though the active
+// filter guarantees it.
 function detailCols(type: ImageType): DetailCol[] {
 	switch (type) {
 		case "os":
@@ -43,7 +69,15 @@ function detailCols(type: ImageType): DetailCol[] {
 				{
 					head: messages.library.columns.size,
 					width: "w-14",
-					cell: (k) => (k.type === "os" ? `${k.sizeClass}K` : ""),
+					render: (k, set) =>
+						k.type === "os" ? (
+							<FilterValue
+								value={`${k.sizeClass}K`}
+								onClick={() => set("sizeClass", k.sizeClass)}
+							/>
+						) : (
+							<></>
+						),
 				},
 			];
 		case "cart":
@@ -51,7 +85,15 @@ function detailCols(type: ImageType): DetailCol[] {
 				{
 					head: messages.library.columns.type,
 					width: "w-14",
-					cell: (k) => (k.type === "cart" ? String(k.cartType) : ""),
+					render: (k, set) =>
+						k.type === "cart" ? (
+							<FilterValue
+								value={k.cartType}
+								onClick={() => set("cartType", k.cartType)}
+							/>
+						) : (
+							<></>
+						),
 				},
 			];
 		case "disk":
@@ -59,8 +101,22 @@ function detailCols(type: ImageType): DetailCol[] {
 				{
 					head: messages.library.detail.geometry,
 					width: "w-24",
-					cell: (k) =>
-						k.type === "disk" ? `${k.sectors}×${k.sectorSize}` : "",
+					render: (k, set) =>
+						k.type === "disk" ? (
+							<>
+								<FilterValue
+									value={k.sectors}
+									onClick={() => set("sectors", k.sectors)}
+								/>
+								×
+								<FilterValue
+									value={k.sectorSize}
+									onClick={() => set("bps", k.sectorSize)}
+								/>
+							</>
+						) : (
+							<></>
+						),
 				},
 			];
 		case "xex":
@@ -119,7 +175,25 @@ export default function LibraryPage() {
 	useEffect(() => {
 		if (folderInputRef.current) folderInputRef.current.webkitdirectory = true;
 	}, []);
-	const [params, setParams] = useUrlParams(["q", "type", "source", "page"]);
+	const [params, setParams] = useUrlParams([
+		"q",
+		"type",
+		"source",
+		"page",
+		"sizeClass",
+		"cartType",
+		"sectors",
+		"bps",
+	]);
+
+	// Set / clear an attribute filter (a detail value, or its chip's ×). The
+	// computed key is a known param, but TS can't see that through the union.
+	const setAttr: SetAttr = (param, value) =>
+		setParams({ [param]: String(value), page: null } as Parameters<
+			typeof setParams
+		>[0]);
+	const clearAttr = (param: AttrParam): void =>
+		setParams({ [param]: null, page: null } as Parameters<typeof setParams>[0]);
 
 	// Pull the user's uploads into the merged list (built-ins are already there).
 	useEffect(() => void readyLibrary(), []);
@@ -182,12 +256,23 @@ export default function LibraryPage() {
 		[entries],
 	);
 
-	const filtered = sorted.filter(
-		(e) =>
-			(typeFilter === "" || e.derived.type === typeFilter) &&
-			(sourceFilter === "" || e.source === sourceFilter) &&
-			(query === "" || e.user.displayName.toLowerCase().includes(query)),
-	);
+	const filtered = sorted.filter((e) => {
+		if (typeFilter !== "" && e.derived.type !== typeFilter) return false;
+		if (sourceFilter !== "" && e.source !== sourceFilter) return false;
+		if (query !== "" && !e.user.displayName.toLowerCase().includes(query))
+			return false;
+		// Attribute filters — apply only to entries of the matching kind.
+		const k = e.derived;
+		if (params.sizeClass && k.type === "os")
+			return String(k.sizeClass) === params.sizeClass;
+		if (params.cartType && k.type === "cart")
+			return String(k.cartType) === params.cartType;
+		if (k.type === "disk") {
+			if (params.sectors && String(k.sectors) !== params.sectors) return false;
+			if (params.bps && String(k.sectorSize) !== params.bps) return false;
+		}
+		return true;
+	});
 
 	const total = filtered.length;
 	const pages = Math.max(1, Math.ceil(total / PAGE_SIZE));
@@ -201,6 +286,26 @@ export default function LibraryPage() {
 	// All-types is a flat list with leading type pills; a type-filtered view is a
 	// table whose extra columns carry that type's attributes.
 	const cols = typeFilter === "" ? [] : detailCols(typeFilter);
+
+	// Active attribute filters, as dismissable chips (only the current type's).
+	const attrFilters: { param: AttrParam; label: string }[] = [];
+	if (typeFilter === "os" && params.sizeClass)
+		attrFilters.push({ param: "sizeClass", label: `${params.sizeClass}K` });
+	if (typeFilter === "cart" && params.cartType)
+		attrFilters.push({
+			param: "cartType",
+			label: `${messages.library.columns.type} ${params.cartType}`,
+		});
+	if (typeFilter === "disk" && params.sectors)
+		attrFilters.push({
+			param: "sectors",
+			label: `${params.sectors} ${messages.library.detail.sectors}`,
+		});
+	if (typeFilter === "disk" && params.bps)
+		attrFilters.push({
+			param: "bps",
+			label: `${params.bps} ${messages.library.detail.bps}`,
+		});
 
 	return (
 		<PanelFrame title={messages.library.title}>
@@ -284,9 +389,15 @@ export default function LibraryPage() {
 							value={typeFilter}
 							class="flex-1 rounded border border-neutral-300 bg-white px-2 py-1 text-sm text-neutral-800"
 							onChange={(event) =>
+								// Changing the type clears any attribute filters — they
+								// only apply within their own type.
 								setParams({
 									type: event.currentTarget.value || null,
 									page: null,
+									sizeClass: null,
+									cartType: null,
+									sectors: null,
+									bps: null,
 								})
 							}
 						>
@@ -313,6 +424,26 @@ export default function LibraryPage() {
 							<option value="user">{messages.library.sourceUser}</option>
 						</select>
 					</div>
+					{attrFilters.length > 0 && (
+						<div class="flex flex-wrap gap-1.5">
+							{attrFilters.map((f) => (
+								<span
+									key={f.param}
+									class="inline-flex items-center gap-1 rounded bg-neutral-100 px-2 py-0.5 text-xs text-neutral-700"
+								>
+									{f.label}
+									<button
+										type="button"
+										aria-label={messages.library.removeFilter}
+										class="cursor-pointer text-neutral-400 hover:text-neutral-700"
+										onClick={() => clearAttr(f.param)}
+									>
+										<Icon name="close" class="size-3" />
+									</button>
+								</span>
+							))}
+						</div>
+					)}
 				</div>
 
 				{total === 0 ? (
@@ -377,7 +508,7 @@ export default function LibraryPage() {
 											key={c.head}
 											class="px-2 py-1 text-right tabular-nums text-neutral-500"
 										>
-											{c.cell(entry.derived)}
+											{c.render(entry.derived, setAttr)}
 										</td>
 									))}
 								</tr>

--- a/apps/a8-web/src/sidebar.tsx
+++ b/apps/a8-web/src/sidebar.tsx
@@ -1,6 +1,5 @@
 import type { EmulatorHost } from "./host.ts";
 import { Icon } from "./icon.tsx";
-import type { ImageType } from "./images/metadata.ts";
 import {
 	anticPolicy,
 	MODELS,
@@ -11,6 +10,7 @@ import {
 } from "./machine-config.ts";
 import { messages } from "./messages.ts";
 import { recentsView } from "./recents.ts";
+import { TypePill } from "./type-pill.tsx";
 
 /**
  * The chord that opens the command palette: Cmd+K on macOS, Alt+K elsewhere.
@@ -100,28 +100,6 @@ function KeyRow({ keys, action }: { keys: string; action: string }) {
 			<dt class="whitespace-nowrap text-neutral-500">{keys}</dt>
 			<dd>{action}</dd>
 		</>
-	);
-}
-
-// Per-type leading pill: a three-letter format code — monospace so they align
-// into a column — tinted by kind. disk → atr, cart → car, xex → xex, os → rom.
-const TYPE_PILL: Record<ImageType, { code: string; tint: string }> = {
-	disk: { code: "atr", tint: "bg-sky-100 text-sky-700" },
-	cart: { code: "car", tint: "bg-amber-100 text-amber-700" },
-	xex: { code: "xex", tint: "bg-emerald-100 text-emerald-700" },
-	os: { code: "rom", tint: "bg-violet-100 text-violet-700" },
-};
-
-/** The leading type pill for a recents row; the full type name is its tooltip. */
-function TypePill({ type }: { type: ImageType }) {
-	const { code, tint } = TYPE_PILL[type];
-	return (
-		<span
-			class={`shrink-0 rounded px-1.5 py-0.5 font-mono text-[10px] leading-none ${tint}`}
-			title={messages.library.typeName[type]}
-		>
-			{code}
-		</span>
 	);
 }
 

--- a/apps/a8-web/src/type-pill.tsx
+++ b/apps/a8-web/src/type-pill.tsx
@@ -1,0 +1,25 @@
+import type { ImageType } from "./images/metadata.ts";
+import { messages } from "./messages.ts";
+
+// Per-type pill: a three-letter format code — monospace so they align into a
+// column — tinted by kind. disk → atr, cart → car, xex → xex, os → rom. Shared
+// by the recents menu and the library view.
+const TYPE_PILL: Record<ImageType, { code: string; tint: string }> = {
+	disk: { code: "atr", tint: "bg-sky-100 text-sky-700" },
+	cart: { code: "car", tint: "bg-amber-100 text-amber-700" },
+	xex: { code: "xex", tint: "bg-emerald-100 text-emerald-700" },
+	os: { code: "rom", tint: "bg-violet-100 text-violet-700" },
+};
+
+/** A colour-coded type pill (format code); the full type name is its tooltip. */
+export function TypePill({ type }: { type: ImageType }) {
+	const { code, tint } = TYPE_PILL[type];
+	return (
+		<span
+			class={`shrink-0 rounded px-1.5 py-0.5 font-mono text-[10px] leading-none ${tint}`}
+			title={messages.library.typeName[type]}
+		>
+			{code}
+		</span>
+	);
+}

--- a/packages/a8/src/canonicalize.test.ts
+++ b/packages/a8/src/canonicalize.test.ts
@@ -54,6 +54,21 @@ function xegsCombined(): Uint8Array {
 	return dump;
 }
 
+// A synthetic ATR: the 16-byte header (magic, paragraph count, sector size)
+// over `dataBytes` of zeroed image data. detectFileFormat only needs the magic.
+function makeAtr(sectorSize: 128 | 256, dataBytes: number): Uint8Array {
+	const atr = new Uint8Array(16 + dataBytes);
+	atr[0] = 0x96;
+	atr[1] = 0x02; // magic 0x0296
+	const paras = dataBytes / 16;
+	atr[2] = paras & 0xff;
+	atr[3] = (paras >> 8) & 0xff;
+	atr[6] = (paras >> 16) & 0xff;
+	atr[4] = sectorSize & 0xff;
+	atr[5] = (sectorSize >> 8) & 0xff;
+	return atr;
+}
+
 const CART_MAGIC = [0x43, 0x41, 0x52, 0x54];
 
 describe("canonicalize", () => {
@@ -107,6 +122,31 @@ describe("canonicalize", () => {
 		expect(detectFileFormat(pieces[0]!.bytes)).toBe("cart");
 		expect(detectFileFormat(pieces[1]!.bytes)).toBe("cart");
 		expect(pieces[2]!.bytes).toHaveLength(16384);
+	});
+
+	it("counts SD disk sectors by a flat 128-byte division", () => {
+		expect(canonicalize(makeAtr(128, 720 * 128))[0]!.kind).toEqual({
+			type: "disk",
+			sectorSize: 128,
+			sectors: 720,
+		});
+	});
+
+	it("counts DD disk sectors honoring the 128-byte boot sectors", () => {
+		// Standard DD: 3 boot sectors at 128 B, the rest at 256 B.
+		expect(canonicalize(makeAtr(256, 3 * 128 + 717 * 256))[0]!.kind).toEqual({
+			type: "disk",
+			sectorSize: 256,
+			sectors: 720,
+		});
+	});
+
+	it("counts a non-standard all-256 DD image by a flat division", () => {
+		expect(canonicalize(makeAtr(256, 720 * 256))[0]!.kind).toEqual({
+			type: "disk",
+			sectorSize: 256,
+			sectors: 720,
+		});
 	});
 
 	it("throws on an unrecognized format", () => {

--- a/packages/a8/src/canonicalize.ts
+++ b/packages/a8/src/canonicalize.ts
@@ -141,11 +141,17 @@ function carPiece(source: Uint8Array): CanonicalPiece {
 function diskPiece(source: Uint8Array): CanonicalPiece {
 	const sectorSize =
 		((source[4] ?? 0) | ((source[5] ?? 0) << 8)) === 256 ? 256 : 128;
-	// Paragraph (16-byte) count → total image bytes; the 128-byte boot-sector
-	// quirk on DD disks is ignored until we actually strip the container.
+	// Paragraph (16-byte) count → total image bytes.
 	const paragraphs =
 		(source[2] ?? 0) | ((source[3] ?? 0) << 8) | ((source[6] ?? 0) << 16);
-	const sectors = Math.floor((paragraphs * 16) / sectorSize);
+	const dataBytes = paragraphs * 16;
+	// DD disks keep the 3 boot sectors at 128 bytes (single density), so dividing
+	// the whole image by 256 undercounts by 2. Honor that layout when the size
+	// fits it; fall back to a flat division (SD, or a non-standard all-256 image).
+	const sectors =
+		sectorSize === 256 && dataBytes >= 384 && (dataBytes - 384) % 256 === 0
+			? 3 + (dataBytes - 384) / 256
+			: Math.floor(dataBytes / sectorSize);
 	return {
 		from: 0,
 		to: source.length,

--- a/packages/a8/src/index.ts
+++ b/packages/a8/src/index.ts
@@ -5,7 +5,7 @@ export {
 	type CanonicalPiece,
 	type ImageKind,
 } from "./canonicalize.ts";
-export { Cartridge } from "./cartridge.ts";
+export { Cartridge, CART_TYPES, type CartType } from "./cartridge.ts";
 export { createSioHandler, SIOV, type SioHandlerOptions } from "./sio.ts";
 export { buildBootDisk } from "./xex-boot.ts";
 export {


### PR DESCRIPTION
Reworks the a8-web image library list and item views, building on the library from #27/#28.

## List view

- **All-types view** is a flat list with a leading colour-coded **type pill** (`atr`/`car`/`rom`/`xex`, monospace so they align). Sorting is dropped (direction wasn't meaningful) in favour of a fixed alphabetical order.
- **Type-filtered views** are tables with per-type columns: OS → size class; cartridge → CART subtype; disk → **Geometry** (`sectors×bps`). Numeric columns are right-aligned (`tabular-nums`); Name takes the remaining width.
- **Click-to-filter**: clicking a detail value filters by it — disk geometry's sectors and bps are independently clickable. Active filters show as dismissable chips; all state lives in the URL (shareable / reload-safe) and is cleared when the type changes.

## Item view

- **Full detail rows** for every fact — source, type, the per-type specifics (cartridge resolves to its full `CART_TYPES` name), size, hash.
- **Well-known firmware** section below the actions: when `detectFirmware` recognizes the image, shows its name (with parsed version), origin, and notes. Detection runs only for OS/cartridge images and unwraps the `.car` header for user uploads.

## Package

- Export `CART_TYPES` / `CartType` from `@sfotty-pie/a8` for the cartridge-subtype name lookup.

`TypePill` is shared between the recents menu and the library. All green: lint, typecheck, unit, build.