### PR TITLE
a8-web: faster, leaner bulk import

### DIFF
--- a/apps/a8-web/src/images/import.worker.ts
+++ b/apps/a8-web/src/images/import.worker.ts
@@ -1,0 +1,84 @@
+/// <reference lib="webworker" />
+
+// The bulk-import worker: ingests an entire file list off the main thread —
+// reading bytes, canonicalizing, hashing, compressing, and writing blobs +
+// entries straight to IndexedDB (the worker is the sole writer for the import's
+// duration). It posts progress back in batches so the library can fill in live
+// without flooding the main thread with a message per file.
+
+import { ingestFile } from "./ingest.ts";
+import type { StoredEntry } from "./metadata.ts";
+import { loadEntries } from "./store.ts";
+
+export interface ImportRequest {
+	files: File[];
+}
+
+export type ImportResponse =
+	| {
+			type: "progress";
+			done: number;
+			total: number;
+			added: number;
+			deduped: number;
+			failed: number;
+			/** Entries written since the previous message (for the live merge). */
+			newEntries: StoredEntry[];
+	  }
+	| { type: "done"; added: number; deduped: number; failed: number };
+
+// Coalesce progress posts to ~10/s so a huge import doesn't drown the main
+// thread; newEntries accumulate between flushes.
+const FLUSH_MS = 100;
+
+const worker = globalThis as unknown as DedicatedWorkerGlobalScope;
+
+worker.onmessage = async (event: MessageEvent<ImportRequest>) => {
+	const { files } = event.data;
+	const total = files.length;
+
+	// Dedup against what's already stored; the worker owns writes for the import.
+	const seen = new Set((await loadEntries()).map((e) => e.hash));
+
+	let added = 0;
+	let deduped = 0;
+	let failed = 0;
+	let done = 0;
+	let batch: StoredEntry[] = [];
+	let lastFlush = performance.now();
+
+	const flush = (force: boolean): void => {
+		if (!force && performance.now() - lastFlush < FLUSH_MS) return;
+		const message: ImportResponse = {
+			type: "progress",
+			done,
+			total,
+			added,
+			deduped,
+			failed,
+			newEntries: batch,
+		};
+		worker.postMessage(message);
+		batch = [];
+		lastFlush = performance.now();
+	};
+
+	for (const file of files) {
+		const into: StoredEntry[] = [];
+		try {
+			const bytes = new Uint8Array(await file.arrayBuffer());
+			const result = await ingestFile(bytes, file.name, seen, into);
+			added += result.added;
+			deduped += result.deduped;
+		} catch {
+			failed++; // unrecognized — canonicalize threw
+		}
+		if (into.length > 0) batch.push(...into);
+		done++;
+		flush(false);
+	}
+	flush(true);
+
+	const done_: ImportResponse = { type: "done", added, deduped, failed };
+	worker.postMessage(done_);
+};

--- a/apps/a8-web/src/images/ingest.ts
+++ b/apps/a8-web/src/images/ingest.ts
@@ -1,0 +1,78 @@
+// The signal-free ingest core: turn file bytes into stored library entries
+// (canonicalize → hash → blob + metadata write). Kept apart from the reactive
+// library facade so it can run unchanged inside the import worker — it touches
+// only IndexedDB, crypto, and CompressionStream, all available off the main
+// thread. Each JS context (main thread, worker) opens its own blob handle to the
+// same database.
+
+import {
+	canonicalize,
+	detectFirmware,
+	type FirmwareType,
+	type ImageKind,
+} from "@sfotty-pie/a8";
+import { idbBlobStore } from "./blob-store.ts";
+import { sha256Hex } from "./hash.ts";
+import type { ImageSlot, StoredEntry } from "./metadata.ts";
+import { putEntry } from "./store.ts";
+
+export const blobs = idbBlobStore();
+
+/** Prime the slot pickers from a firmware type — standard-8K carts only. */
+export function primeSlots(
+	type: FirmwareType | null,
+	kind: ImageKind,
+): ImageSlot[] | undefined {
+	if (kind.type !== "cart") return undefined;
+	if (type === "basic") return ["basic"];
+	if (type === "game") return ["game"];
+	return undefined;
+}
+
+// Ingest one file's canonical pieces into `into`, deduping against `seen` (a set
+// of hashes it updates — including earlier pieces in the same batch). Does the
+// blob + metadata writes. Throws if the file isn't a recognized image. A
+// built-in match is never a reason to skip storing (a later deploy may drop the
+// built-in), so `seen` holds only user hashes.
+export async function ingestFile(
+	bytes: Uint8Array,
+	fileName: string,
+	seen: Set<string>,
+	into: StoredEntry[],
+	transient = false,
+): Promise<{ added: number; deduped: number }> {
+	const pieces = canonicalize(bytes, fileName); // throws on an unrecognized file
+	const baseName = fileName.replace(/\.[^./]+$/, "");
+	let added = 0;
+	let deduped = 0;
+	for (const piece of pieces) {
+		const hash = await sha256Hex(piece.bytes);
+		if (seen.has(hash)) {
+			deduped++; // already in the user's library
+			continue;
+		}
+		seen.add(hash);
+		const raw = bytes.subarray(piece.from, piece.to);
+		const fw = detectFirmware(raw);
+		const slots = primeSlots(fw?.type ?? null, piece.kind);
+		const entry: StoredEntry = {
+			id: crypto.randomUUID(),
+			hash,
+			size: piece.bytes.length,
+			createdAt: Date.now(),
+			...(transient && { transient: true }),
+			locator: { backend: "idb", ref: hash },
+			derived: piece.kind,
+			user: {
+				displayName:
+					fw?.name ?? (piece.role ? `${baseName} (${piece.role})` : baseName),
+				...(slots && { slots }),
+			},
+		};
+		await blobs.put(hash, piece.bytes);
+		await putEntry(entry);
+		into.push(entry);
+		added++;
+	}
+	return { added, deduped };
+}

--- a/apps/a8-web/src/images/library.ts
+++ b/apps/a8-web/src/images/library.ts
@@ -4,25 +4,16 @@
 // uploaded, and where its bytes physically live.
 
 import { computed, signal } from "@preact/signals";
-import {
-	canonicalize,
-	detectFirmware,
-	type FirmwareType,
-	type ImageKind,
-} from "@sfotty-pie/a8";
+import { canonicalize, type ImageKind } from "@sfotty-pie/a8";
 import {
 	builtinFirmware,
 	type FirmwareLibraryEntry,
 } from "virtual:firmware-library";
-import { idbBlobStore } from "./blob-store.ts";
 import { loadImageBytes } from "./fetch.ts";
 import { sha256Hex } from "./hash.ts";
-import type {
-	ImageEntry,
-	ImageSlot,
-	StoredEntry,
-	UserMeta,
-} from "./metadata.ts";
+import type { ImportRequest, ImportResponse } from "./import.worker.ts";
+import { blobs, ingestFile, primeSlots } from "./ingest.ts";
+import type { ImageEntry, StoredEntry, UserMeta } from "./metadata.ts";
 import {
 	clearAll,
 	deleteEntry,
@@ -30,8 +21,6 @@ import {
 	loadOverrides,
 	putEntry,
 } from "./store.ts";
-
-const blobs = idbBlobStore();
 
 /**
  * A bulk import's phase: `preparing` while the dropped folder tree is walked
@@ -84,17 +73,6 @@ export function readyLibrary(): Promise<void> {
 /** A built-in's stable identity: its firmware key when known, else its path id. */
 function builtinId(fw: FirmwareLibraryEntry): string {
 	return fw.firmwareKey ?? fw.id;
-}
-
-/** Prime the slot pickers from a firmware type — standard-8K carts only. */
-function primeSlots(
-	type: FirmwareType | null,
-	kind: ImageKind,
-): ImageSlot[] | undefined {
-	if (kind.type !== "cart") return undefined;
-	if (type === "basic") return ["basic"];
-	if (type === "game") return ["game"];
-	return undefined;
 }
 
 function builtinEntry(
@@ -219,54 +197,6 @@ export interface BulkAddResult {
 	failed: number;
 }
 
-// Ingest one file's canonical pieces into `into`, deduping against `seen` (a set
-// of hashes it updates — including earlier pieces in the same batch). Does the
-// blob + metadata writes. Throws if the file isn't a recognized image. A
-// built-in match is never a reason to skip storing (a later deploy may drop the
-// built-in), so `seen` holds only user hashes.
-async function ingestFile(
-	bytes: Uint8Array,
-	fileName: string,
-	seen: Set<string>,
-	into: StoredEntry[],
-	transient = false,
-): Promise<{ added: number; deduped: number }> {
-	const pieces = canonicalize(bytes, fileName); // throws on an unrecognized file
-	const baseName = fileName.replace(/\.[^./]+$/, "");
-	let added = 0;
-	let deduped = 0;
-	for (const piece of pieces) {
-		const hash = await sha256Hex(piece.bytes);
-		if (seen.has(hash)) {
-			deduped++; // already in the user's library
-			continue;
-		}
-		seen.add(hash);
-		const raw = bytes.subarray(piece.from, piece.to);
-		const fw = detectFirmware(raw);
-		const slots = primeSlots(fw?.type ?? null, piece.kind);
-		const entry: StoredEntry = {
-			id: crypto.randomUUID(),
-			hash,
-			size: piece.bytes.length,
-			createdAt: Date.now(),
-			...(transient && { transient: true }),
-			locator: { backend: "idb", ref: hash },
-			derived: piece.kind,
-			user: {
-				displayName:
-					fw?.name ?? (piece.role ? `${baseName} (${piece.role})` : baseName),
-				...(slots && { slots }),
-			},
-		};
-		await blobs.put(hash, piece.bytes);
-		await putEntry(entry);
-		into.push(entry);
-		added++;
-	}
-	return { added, deduped };
-}
-
 /**
  * Resolve an in-memory image (e.g. one being booted/attached from the file
  * picker) to a library id: return the existing entry's id if its canonical bytes
@@ -328,39 +258,49 @@ export async function addImage(
  * panel. Unrecognized files are counted, not thrown. Slow but live at thousands
  * of items — chunked batching is the lever if that changes.
  */
-export async function addFiles(files: File[]): Promise<BulkAddResult> {
-	await readyLibrary();
-	const seen = new Set(userEntries.value.map((e) => e.hash));
-	let added = 0;
-	let deduped = 0;
-	let failed = 0;
-	let done = 0;
+export function addFiles(files: File[]): Promise<BulkAddResult> {
 	const total = files.length;
 	const startedAt = performance.now();
 	importProgress.value = { phase: "adding", done: 0, total, elapsedMs: 0 };
-	try {
-		for (const file of files) {
-			const into: StoredEntry[] = [];
-			try {
-				const bytes = new Uint8Array(await file.arrayBuffer());
-				const result = await ingestFile(bytes, file.name, seen, into);
-				added += result.added;
-				deduped += result.deduped;
-			} catch {
-				failed++; // unrecognized — canonicalize threw
-			}
-			if (into.length > 0) userEntries.value = [...userEntries.value, ...into];
-			importProgress.value = {
-				phase: "adding",
-				done: ++done,
-				total,
-				elapsedMs: performance.now() - startedAt,
+	return new Promise<BulkAddResult>((resolve) => {
+		// Load existing entries first so the worker's live-appended results land on
+		// top of the full set (the worker independently reads the same IDB snapshot
+		// to dedup; it's the sole writer for the import's duration).
+		void readyLibrary().then(() => {
+			const worker = new Worker(
+				new URL("./import.worker.ts", import.meta.url),
+				{ type: "module" },
+			);
+			const finish = (result: BulkAddResult): void => {
+				importProgress.value = null;
+				worker.terminate();
+				resolve(result);
 			};
-		}
-	} finally {
-		importProgress.value = null;
-	}
-	return { added, deduped, failed };
+			worker.onmessage = (event: MessageEvent<ImportResponse>) => {
+				const message = event.data;
+				if (message.type === "done") {
+					finish({
+						added: message.added,
+						deduped: message.deduped,
+						failed: message.failed,
+					});
+					return;
+				}
+				// Merge the batch of just-written entries so the library fills in live.
+				if (message.newEntries.length > 0) {
+					userEntries.value = [...userEntries.value, ...message.newEntries];
+				}
+				importProgress.value = {
+					phase: "adding",
+					done: message.done,
+					total,
+					elapsedMs: performance.now() - startedAt,
+				};
+			};
+			worker.onerror = () => finish({ added: 0, deduped: 0, failed: total });
+			worker.postMessage({ files } satisfies ImportRequest);
+		});
+	});
 }
 
 /**

--- a/apps/a8-web/src/messages.ts
+++ b/apps/a8-web/src/messages.ts
@@ -134,7 +134,7 @@ export const messages = {
 
 	library: {
 		title: "Library",
-		drop: "Drop ROM files or folders here, or",
+		drop: "Drop files or folders here, or",
 		browse: "browse files",
 		browseFolder: "a folder",
 		empty: "No images yet.",
@@ -189,8 +189,9 @@ export const messages = {
 			sectors: "Sectors",
 			sectorSize: "Sector size",
 		},
-		// Heading for the item view's recognized-firmware section.
-		firmwareTitle: "Well-known firmware",
+		// Heading for the item view's recognized-image section (firmware today;
+		// DOSes and other known software later).
+		knownTitle: "Well-known image",
 		typeName: {
 			os: "OS",
 			cart: "Cartridge",

--- a/apps/a8-web/src/routes/a8/emu/library-item.page.tsx
+++ b/apps/a8-web/src/routes/a8/emu/library-item.page.tsx
@@ -284,7 +284,7 @@ export default function LibraryItemPanel({ id: rawId }: { id: string }) {
 				{firmware && (
 					<div class="flex flex-col gap-1 border-t border-neutral-200 pt-3">
 						<h3 class="text-xs font-semibold tracking-wide text-neutral-500 uppercase">
-							{messages.library.firmwareTitle}
+							{messages.library.knownTitle}
 						</h3>
 						<p class="text-sm font-medium text-neutral-800">{firmware.name}</p>
 						<p class="text-xs text-neutral-500">{firmware.origin}</p>

--- a/apps/a8-web/src/routes/a8/emu/library.page.tsx
+++ b/apps/a8-web/src/routes/a8/emu/library.page.tsx
@@ -1,3 +1,4 @@
+import { hasKnownExtension } from "@sfotty-pie/a8";
 import type { VNode } from "preact";
 import { useEffect, useMemo, useRef, useState } from "preact/hooks";
 import { Icon } from "../../../icon.tsx";
@@ -143,9 +144,12 @@ function readEntries(
 	return new Promise((resolve, reject) => reader.readEntries(resolve, reject));
 }
 
-// Collect files from a dropped entry, recursing into directories.
+// Collect files from a dropped entry, recursing into directories. Files whose
+// name can't be a recognized image (e.g. the PNGs in a ROM archive) are skipped
+// by extension before being read.
 async function walkEntry(entry: FileSystemEntry, out: File[]): Promise<void> {
 	if (entry.isFile) {
+		if (!hasKnownExtension(entry.name)) return;
 		out.push(
 			await new Promise<File>((resolve, reject) =>
 				(entry as FileSystemFileEntry).file(resolve, reject),
@@ -169,7 +173,8 @@ async function filesFromDrop(transfer: DataTransfer): Promise<File[]> {
 	const entries = Array.from(transfer.items)
 		.map((item) => item.webkitGetAsEntry())
 		.filter((entry): entry is FileSystemEntry => entry !== null);
-	if (entries.length === 0) return Array.from(transfer.files);
+	if (entries.length === 0)
+		return Array.from(transfer.files).filter((f) => hasKnownExtension(f.name));
 	const out: File[] = [];
 	await Promise.all(entries.map((entry) => walkEntry(entry, out)));
 	return out;
@@ -377,7 +382,11 @@ export default function LibraryPage() {
 						type="file"
 						class="hidden"
 						onChange={(event) => {
-							const files = Array.from(event.currentTarget.files ?? []);
+							// A folder picker yields everything in the tree; drop names
+							// that can't be images before reading them.
+							const files = Array.from(event.currentTarget.files ?? []).filter(
+								(f) => hasKnownExtension(f.name),
+							);
 							event.currentTarget.value = "";
 							void runImport(async () => files);
 						}}

--- a/packages/a8/src/detect-file-format.ts
+++ b/packages/a8/src/detect-file-format.ts
@@ -9,12 +9,43 @@ export type AtariFileFormat =
 	| "os-rom-16k"
 	| "xegs-rom-32k";
 
+// Filename extensions each detector accepts (the content check still confirms).
+// A format matches a named file only when its extension is in its list; a
+// nameless blob (e.g. a built-in served raw) matches on content alone.
+const ATR = ["atr"];
+const XEX = ["xex", "axe", "exe", "com", "obj", "bin", "obx"];
+// Raw ROM dumps: raw cartridges, OS ROMs, and the XEGS 32K dump.
+const RAW_ROM = ["rom", "bin", "raw"];
+const CAR = ["car"];
+
+const extMatcher = (exts: readonly string[]): RegExp =>
+	new RegExp(`\\.(?:${exts.join("|")})$`, "i");
+
+const ATR_RE = extMatcher(ATR);
+const XEX_RE = extMatcher(XEX);
+const RAW_ROM_RE = extMatcher(RAW_ROM);
+const CAR_RE = extMatcher(CAR);
+
+// The union of every accepted extension, derived from the lists above so it
+// can't drift out of sync.
+const KNOWN_RE = extMatcher([...new Set([...ATR, ...XEX, ...RAW_ROM, ...CAR])]);
+
+/**
+ * Whether a filename's extension is one any detector accepts — a cheap,
+ * name-only pre-filter (the content check still confirms the actual format). Use
+ * it to skip clearly-irrelevant files (e.g. the PNGs in a ROM archive) before
+ * reading them when bulk-importing a directory.
+ */
+export function hasKnownExtension(name: string): boolean {
+	return KNOWN_RE.test(name);
+}
+
 export function detectFileFormat(
 	contents: Uint8Array,
 	name?: string,
 ): AtariFileFormat | null {
 	if (
-		(!name || name.match(/\.atr$/i)) &&
+		(!name || ATR_RE.test(name)) &&
 		contents[0] === 0x96 &&
 		contents[1] === 0x02
 	) {
@@ -22,40 +53,40 @@ export function detectFileFormat(
 	}
 
 	if (
-		(!name || name.match(/\.(?:xex|axe|exe|com|obj|bin|obx)$/i)) &&
+		(!name || XEX_RE.test(name)) &&
 		contents[0] === 0xff &&
 		contents[1] === 0xff
 	) {
 		return "xex";
 	}
 
-	if (!name || name.match(/\.(?:rom|bin|raw)$/i)) {
+	if (!name || RAW_ROM_RE.test(name)) {
 		const cartType = getRawCartType(contents);
 		if (cartType) {
 			return cartType;
 		}
+
+		if (isOsRom(contents)) {
+			return contents.length === 16384 ? "os-rom-16k" : "os-rom-10k";
+		}
+
+		// The XEGS internal ROM is a 32K dump laid out as two 8K $A000-$BFFF
+		// carts (the built-in game and BASIC) followed by the 16K XL/XE OS.
+		// Detect it structurally from its pieces rather than by signature.
+		if (
+			contents.length === 32768 &&
+			getRawCartType(contents.subarray(0, 0x2000)) ===
+				"raw-cart-8k-a000-bfff" &&
+			getRawCartType(contents.subarray(0x2000, 0x4000)) ===
+				"raw-cart-8k-a000-bfff" &&
+			isOsRom(contents.subarray(0x4000, 0x8000))
+		) {
+			return "xegs-rom-32k";
+		}
 	}
 
-	if ((!name || name.match(/\.(?:rom|bin)$/i)) && isOsRom(contents)) {
-		return contents.length === 16384 ? "os-rom-16k" : "os-rom-10k";
-	}
-
-	// The XEGS internal ROM is a 32K dump laid out as two 8K $A000-$BFFF carts
-	// (the built-in game and BASIC) followed by the 16K XL/XE OS. Detect it
-	// structurally from its pieces rather than by signature.
 	if (
-		(!name || name.match(/\.(?:rom|bin|raw)$/i)) &&
-		contents.length === 32768 &&
-		getRawCartType(contents.subarray(0, 0x2000)) === "raw-cart-8k-a000-bfff" &&
-		getRawCartType(contents.subarray(0x2000, 0x4000)) ===
-			"raw-cart-8k-a000-bfff" &&
-		isOsRom(contents.subarray(0x4000, 0x8000))
-	) {
-		return "xegs-rom-32k";
-	}
-
-	if (
-		(!name || name.match(/\.car$/i)) &&
+		(!name || CAR_RE.test(name)) &&
 		contents[0] === 0x43 && // 'C'
 		contents[1] === 0x41 && // 'A'
 		contents[2] === 0x52 && // 'R'

--- a/packages/a8/src/index.ts
+++ b/packages/a8/src/index.ts
@@ -10,6 +10,7 @@ export { createSioHandler, SIOV, type SioHandlerOptions } from "./sio.ts";
 export { buildBootDisk } from "./xex-boot.ts";
 export {
 	detectFileFormat,
+	hasKnownExtension,
 	type AtariFileFormat,
 } from "./detect-file-format.ts";
 export {


### PR DESCRIPTION
Improves bulk image imports (e.g. a whole ROM archive): skip irrelevant files without reading them, run the ingest off the main thread, and broaden some now-too-narrow wording.

## Changes

- **Prefilter by extension** — extracted the per-format filename matchers in `detect-file-format.ts` into a `hasKnownExtension` helper (a union derived from the per-format lists, so it can't drift), and use it in the directory walk / drop / folder picker to skip files that can't be images (the PNGs in Fandal's archive, etc.) *before* reading them. Also merged `RAW_CART` + `OS_ROM` into one `RAW_ROM` (single extension test), and OS ROMs now accept `.raw`.
- **Import in a worker** — the whole ingest (read → canonicalize → hash → compress → write blobs + entries to IndexedDB) now runs in a dedicated Worker, so a large import no longer janks the UI. The signal-free core lives in a new `images/ingest.ts` (shared by the main thread and the worker); `addFiles` is now a thin controller that spawns the worker and, on each batched progress message (~10/s), appends the new entries to the library signal so it still fills in live. `addImage`/`addOrFindImage` stay on the main thread (existing tests unchanged).
- **Wording** — the drop zone says "Drop files or folders here" (not just ROMs), and the item-view "Well-known firmware" section is now "Well-known image" (it'll cover DOSes and other known software later).

All green: lint, typecheck, unit, build. The worker path was hand-tested by importing a large folder (UI stays responsive, entries fill in live, summary correct).