### PR TITLE
a8-web: library tags

### DIFF
--- a/apps/a8-web/src/images/import.worker.ts
+++ b/apps/a8-web/src/images/import.worker.ts
@@ -12,6 +12,8 @@ import { loadEntries } from "./store.ts";
 
 export interface ImportRequest {
 	files: File[];
+	/** Tags stamped onto every imported entry (already normalized). */
+	tags: string[];
 }
 
 export type ImportResponse =
@@ -34,7 +36,7 @@ const FLUSH_MS = 100;
 const worker = globalThis as unknown as DedicatedWorkerGlobalScope;
 
 worker.onmessage = async (event: MessageEvent<ImportRequest>) => {
-	const { files } = event.data;
+	const { files, tags } = event.data;
 	const total = files.length;
 
 	// Dedup against what's already stored; the worker owns writes for the import.
@@ -67,7 +69,14 @@ worker.onmessage = async (event: MessageEvent<ImportRequest>) => {
 		const into: StoredEntry[] = [];
 		try {
 			const bytes = new Uint8Array(await file.arrayBuffer());
-			const result = await ingestFile(bytes, file.name, seen, into);
+			const result = await ingestFile(
+				bytes,
+				file.name,
+				seen,
+				into,
+				false,
+				tags,
+			);
 			added += result.added;
 			deduped += result.deduped;
 		} catch {

--- a/apps/a8-web/src/images/ingest.ts
+++ b/apps/a8-web/src/images/ingest.ts
@@ -40,6 +40,7 @@ export async function ingestFile(
 	seen: Set<string>,
 	into: StoredEntry[],
 	transient = false,
+	tags: string[] = [],
 ): Promise<{ added: number; deduped: number }> {
 	const pieces = canonicalize(bytes, fileName); // throws on an unrecognized file
 	const baseName = fileName.replace(/\.[^./]+$/, "");
@@ -68,6 +69,7 @@ export async function ingestFile(
 				displayName:
 					fw?.name ?? (piece.role ? `${baseName} (${piece.role})` : baseName),
 				...(slots && { slots }),
+				...(tags.length > 0 && { tags }),
 			},
 		};
 		await blobs.put(hash, piece.bytes);

--- a/apps/a8-web/src/images/library.ts
+++ b/apps/a8-web/src/images/library.ts
@@ -291,7 +291,10 @@ export async function addImage(
  * panel. Unrecognized files are counted, not thrown. Slow but live at thousands
  * of items — chunked batching is the lever if that changes.
  */
-export function addFiles(files: File[]): Promise<BulkAddResult> {
+export function addFiles(
+	files: File[],
+	tags: string[] = [],
+): Promise<BulkAddResult> {
 	const total = files.length;
 	const startedAt = performance.now();
 	importProgress.value = { phase: "adding", done: 0, total, elapsedMs: 0 };
@@ -331,7 +334,7 @@ export function addFiles(files: File[]): Promise<BulkAddResult> {
 				};
 			};
 			worker.onerror = () => finish({ added: 0, deduped: 0, failed: total });
-			worker.postMessage({ files } satisfies ImportRequest);
+			worker.postMessage({ files, tags } satisfies ImportRequest);
 		});
 	});
 }

--- a/apps/a8-web/src/messages.ts
+++ b/apps/a8-web/src/messages.ts
@@ -133,6 +133,7 @@ export const messages = {
 	library: {
 		title: "Library",
 		drop: "Drop files or folders here, or",
+		importTags: "Tag imported files (comma-separated)…",
 		browse: "browse files",
 		browseFolder: "a folder",
 		empty: "No images yet.",
@@ -161,6 +162,7 @@ export const messages = {
 		search: "Filter by name…",
 		allTypes: "All types",
 		allSources: "All sources",
+		allTags: "All tags",
 		sourceBuiltin: "Built-in",
 		sourceUser: "Yours",
 		prev: "Prev",
@@ -197,6 +199,11 @@ export const messages = {
 		},
 		save: "Save",
 		renamed: (name: string): string => `Renamed to ${name}`,
+		tags: {
+			label: "Tags",
+			add: "Add a tag…",
+			remove: "Remove tag",
+		},
 		// Heading for the item view's recognized-image section (firmware today;
 		// DOSes and other known software later).
 		knownTitle: "Well-known image",

--- a/apps/a8-web/src/routes/a8/emu/library-item.page.tsx
+++ b/apps/a8-web/src/routes/a8/emu/library-item.page.tsx
@@ -5,6 +5,7 @@ import {
 	type FirmwareInfo,
 } from "@sfotty-pie/a8";
 import { useEffect, useState } from "preact/hooks";
+import { Icon } from "../../../icon.tsx";
 import {
 	getImage,
 	getImageBytes,
@@ -154,6 +155,64 @@ function NameEditor({
 	);
 }
 
+// Free-form tags as removable chips plus an add field. Tags are normalized
+// (trimmed, lower-cased, deduped); changes apply immediately (the chip is the
+// feedback). Keyed by id by the caller so the draft resets between images.
+function TagEditor({ entry }: { entry: ImageEntry }) {
+	const [draft, setDraft] = useState("");
+	const tags = entry.user.tags ?? [];
+	const add = (raw: string): void => {
+		const tag = raw.trim().toLowerCase();
+		setDraft("");
+		if (tag && !tags.includes(tag)) {
+			void updateUserMeta(entry.id, { tags: [...tags, tag] });
+		}
+	};
+	const remove = (tag: string): void => {
+		void updateUserMeta(entry.id, { tags: tags.filter((t) => t !== tag) });
+	};
+	return (
+		<div class="flex flex-col gap-1">
+			<span class="text-xs text-neutral-500">
+				{messages.library.tags.label}
+			</span>
+			<div class="flex flex-wrap items-center gap-1">
+				{tags.map((tag) => (
+					<span
+						key={tag}
+						class="inline-flex items-center gap-1 rounded bg-neutral-100 px-1.5 py-0.5 text-xs text-neutral-700"
+					>
+						{tag}
+						<button
+							type="button"
+							aria-label={messages.library.tags.remove}
+							class="text-neutral-400 hover:text-neutral-700"
+							onClick={() => remove(tag)}
+						>
+							<Icon name="close" class="size-3" />
+						</button>
+					</span>
+				))}
+				<input
+					type="text"
+					value={draft}
+					placeholder={messages.library.tags.add}
+					autocapitalize="off"
+					class="min-w-24 flex-1 rounded border border-neutral-300 px-2 py-0.5 text-xs text-neutral-900 placeholder-neutral-400 outline-none focus:border-neutral-500"
+					onInput={(event) => setDraft(event.currentTarget.value)}
+					onKeyDown={(event) => {
+						if (event.key === "Enter" || event.key === ",") {
+							event.preventDefault();
+							add(draft);
+						}
+					}}
+					onBlur={() => add(draft)}
+				/>
+			</div>
+		</div>
+	);
+}
+
 export default function LibraryItemPanel({ id: rawId }: { id: string }) {
 	const { host } = useEmu();
 	const [ready, setReady] = useState(false);
@@ -270,6 +329,7 @@ export default function LibraryItemPanel({ id: rawId }: { id: string }) {
 					entry={entry}
 					toast={(message) => host.toast(message)}
 				/>
+				<TagEditor key={`tags-${entry.id}`} entry={entry} />
 
 				<div class="flex flex-col gap-1.5">
 					<Detail

--- a/apps/a8-web/src/routes/a8/emu/library.page.tsx
+++ b/apps/a8-web/src/routes/a8/emu/library.page.tsx
@@ -39,6 +39,18 @@ type OsFamily = keyof typeof OS_FAMILY;
 const osFamilyOf = (sizeClass: number): OsFamily =>
 	sizeClass === 10 ? "400-800" : "xl-xe";
 
+// Comma-separated tag text → normalized tags (trimmed, lower-cased, deduped).
+function parseTags(text: string): string[] {
+	return [
+		...new Set(
+			text
+				.split(",")
+				.map((t) => t.trim().toLowerCase())
+				.filter(Boolean),
+		),
+	];
+}
+
 // The attribute filters a detail value can set (URL params); only meaningful
 // within the matching type-filtered view.
 type AttrParam = "os" | "cartType" | "sectors" | "bps";
@@ -185,6 +197,8 @@ export default function LibraryPage() {
 	const inputRef = useRef<HTMLInputElement>(null);
 	const folderInputRef = useRef<HTMLInputElement>(null);
 	const [dragging, setDragging] = useState(false);
+	// Tags stamped onto everything imported next (applies to drop + both pickers).
+	const [importTags, setImportTags] = useState("");
 
 	// `webkitdirectory` makes the second picker choose a folder (all files in it).
 	// Set imperatively — it isn't in the JSX input attribute types.
@@ -195,6 +209,7 @@ export default function LibraryPage() {
 		"q",
 		"type",
 		"source",
+		"tag",
 		"page",
 		"os",
 		"cartType",
@@ -233,7 +248,8 @@ export default function LibraryPage() {
 			importProgress.value = null;
 			return;
 		}
-		const result = await addFiles(files); // takes over the indicator, clears it
+		// takes over the indicator, clears it; stamps the tags entered above
+		const result = await addFiles(files, parseTags(importTags));
 		const seconds = (performance.now() - start) / 1000;
 		host.toast(
 			messages.library.uploaded(
@@ -255,12 +271,17 @@ export default function LibraryPage() {
 			? params.source
 			: "";
 	const query = params.q.trim().toLowerCase();
+	const tagFilter = params.tag;
 
 	// Auto-added (transient) images are hidden from the curated list; recents
 	// surface them later.
 	const allEntries = libraryEntries.value;
 	const entries = allEntries.filter((entry) => !entry.transient);
 	const hasUploads = allEntries.some((entry) => entry.source === "user");
+	// Distinct tags across the curated set — the tag filter's options.
+	const tagOptions = [
+		...new Set(entries.flatMap((e) => e.user.tags ?? [])),
+	].sort();
 
 	// Fixed alphabetical order (sorting was dropped — direction wasn't
 	// meaningful); filtering below preserves order, so typing never re-sorts.
@@ -275,6 +296,7 @@ export default function LibraryPage() {
 	const filtered = sorted.filter((e) => {
 		if (typeFilter !== "" && e.derived.type !== typeFilter) return false;
 		if (sourceFilter !== "" && e.source !== sourceFilter) return false;
+		if (tagFilter !== "" && !e.user.tags?.includes(tagFilter)) return false;
 		if (query !== "" && !e.user.displayName.toLowerCase().includes(query))
 			return false;
 		// Attribute filters — apply only to entries of the matching kind.
@@ -393,6 +415,17 @@ export default function LibraryPage() {
 					/>
 				</div>
 
+				<input
+					type="text"
+					value={importTags}
+					placeholder={messages.library.importTags}
+					autocapitalize="off"
+					autocomplete="off"
+					spellcheck={false}
+					class="w-full rounded border border-neutral-300 px-2 py-1 text-sm text-neutral-900 placeholder-neutral-400 outline-none focus:border-neutral-500"
+					onInput={(event) => setImportTags(event.currentTarget.value)}
+				/>
+
 				<div class="flex flex-col gap-2">
 					<input
 						type="text"
@@ -406,11 +439,11 @@ export default function LibraryPage() {
 							setParams({ q: event.currentTarget.value || null, page: null })
 						}
 					/>
-					<div class="flex gap-2">
+					<div class="flex flex-wrap gap-2">
 						<select
 							aria-label={messages.library.columns.type}
 							value={typeFilter}
-							class="flex-1 rounded border border-neutral-300 bg-white px-2 py-1 text-sm text-neutral-800"
+							class="min-w-32 flex-1 rounded border border-neutral-300 bg-white px-2 py-1 text-sm text-neutral-800"
 							onChange={(event) =>
 								// Changing the type clears any attribute filters — they
 								// only apply within their own type.
@@ -434,7 +467,7 @@ export default function LibraryPage() {
 						<select
 							aria-label={messages.library.columns.source}
 							value={sourceFilter}
-							class="flex-1 rounded border border-neutral-300 bg-white px-2 py-1 text-sm text-neutral-800"
+							class="min-w-32 flex-1 rounded border border-neutral-300 bg-white px-2 py-1 text-sm text-neutral-800"
 							onChange={(event) =>
 								setParams({
 									source: event.currentTarget.value || null,
@@ -446,6 +479,26 @@ export default function LibraryPage() {
 							<option value="builtin">{messages.library.sourceBuiltin}</option>
 							<option value="user">{messages.library.sourceUser}</option>
 						</select>
+						{tagOptions.length > 0 && (
+							<select
+								aria-label={messages.library.tags.label}
+								value={tagFilter}
+								class="min-w-32 flex-1 rounded border border-neutral-300 bg-white px-2 py-1 text-sm text-neutral-800"
+								onChange={(event) =>
+									setParams({
+										tag: event.currentTarget.value || null,
+										page: null,
+									})
+								}
+							>
+								<option value="">{messages.library.allTags}</option>
+								{tagOptions.map((tag) => (
+									<option key={tag} value={tag}>
+										{tag}
+									</option>
+								))}
+							</select>
+						)}
 					</div>
 					{attrFilters.length > 0 && (
 						<div class="flex flex-wrap gap-1.5">


### PR DESCRIPTION
Adds free-form tags to library images — stamped at import, editable per item, and used to filter the list.

## What's in it

- **Tag at import** — a "Tag imported files" field by the drop zone; whatever's entered (comma-separated, normalized to lower-case/trimmed/deduped) is stamped onto every item of that import, carried through the worker into `ingestFile`.
- **Per-item editor** — an item's view gains a **Tags** section: existing tags as removable chips plus an add field (Enter or comma to add). Persists via `updateUserMeta`, so it works for built-ins too (as an override).
- **List filter** — an **All tags** select appears in the filter row once any tags exist; picking one filters the list. State lives in the URL (`tag`), so it's shareable / reload-safe.

## Layout

The filter row now wraps (`flex-wrap`, `min-w-32` per select) so the three selects reflow to two rows at the panel's width instead of squishing — fixes the cramped side-by-side on both desktop and mobile.

Tags are stored in `UserMeta.tags` (the field already existed). All green: lint, typecheck, unit, build. Hand-tested: tag-on-import, add/remove on an item, filtering, and the wrap.