### PR TITLE
feat(a8-web): library zip import/export

### DIFF
--- a/apps/a8-web/package.json
+++ b/apps/a8-web/package.json
@@ -16,6 +16,7 @@
     "@preact/signals": "^2.9.2",
     "@sfotty-pie/a8": "workspace:*",
     "@sfotty-pie/sfotty": "workspace:*",
+    "fflate": "^0.8.3",
     "preact": "^10.29.2",
     "preact-iso": "^2.12.0"
   },

--- a/apps/a8-web/src/images/import.worker.ts
+++ b/apps/a8-web/src/images/import.worker.ts
@@ -69,14 +69,9 @@ worker.onmessage = async (event: MessageEvent<ImportRequest>) => {
 		const into: StoredEntry[] = [];
 		try {
 			const bytes = new Uint8Array(await file.arrayBuffer());
-			const result = await ingestFile(
-				bytes,
-				file.name,
-				seen,
-				into,
-				false,
+			const result = await ingestFile(bytes, file.name, seen, into, false, {
 				tags,
-			);
+			});
 			added += result.added;
 			deduped += result.deduped;
 		} catch {

--- a/apps/a8-web/src/images/ingest.ts
+++ b/apps/a8-web/src/images/ingest.ts
@@ -13,7 +13,7 @@ import {
 } from "@sfotty-pie/a8";
 import { idbBlobStore } from "./blob-store.ts";
 import { sha256Hex } from "./hash.ts";
-import type { ImageSlot, StoredEntry } from "./metadata.ts";
+import type { ImageSlot, StoredEntry, UserMeta } from "./metadata.ts";
 import { putEntry } from "./store.ts";
 
 export const blobs = idbBlobStore();
@@ -40,7 +40,7 @@ export async function ingestFile(
 	seen: Set<string>,
 	into: StoredEntry[],
 	transient = false,
-	tags: string[] = [],
+	meta: Partial<UserMeta> = {},
 ): Promise<{ added: number; deduped: number }> {
 	const pieces = canonicalize(bytes, fileName); // throws on an unrecognized file
 	const baseName = fileName.replace(/\.[^./]+$/, "");
@@ -55,7 +55,17 @@ export async function ingestFile(
 		seen.add(hash);
 		const raw = bytes.subarray(piece.from, piece.to);
 		const fw = detectFirmware(raw);
-		const slots = primeSlots(fw?.type ?? null, piece.kind);
+		// Supplied metadata (a zip import's manifest) wins over the auto-derived
+		// name/slots; everything else stays content-derived.
+		const slots = meta.slots ?? primeSlots(fw?.type ?? null, piece.kind);
+		const user: UserMeta = {
+			displayName:
+				meta.displayName ??
+				fw?.name ??
+				(piece.role ? `${baseName} (${piece.role})` : baseName),
+		};
+		if (slots?.length) user.slots = slots;
+		if (meta.tags?.length) user.tags = meta.tags;
 		const entry: StoredEntry = {
 			id: crypto.randomUUID(),
 			hash,
@@ -65,12 +75,7 @@ export async function ingestFile(
 			...(fw && { firmwareKey: fw.key }),
 			locator: { backend: "idb", ref: hash },
 			derived: piece.kind,
-			user: {
-				displayName:
-					fw?.name ?? (piece.role ? `${baseName} (${piece.role})` : baseName),
-				...(slots && { slots }),
-				...(tags.length > 0 && { tags }),
-			},
+			user,
 		};
 		await blobs.put(hash, piece.bytes);
 		await putEntry(entry);

--- a/apps/a8-web/src/images/library.ts
+++ b/apps/a8-web/src/images/library.ts
@@ -14,6 +14,7 @@ import { sha256Hex } from "./hash.ts";
 import type { ImportRequest, ImportResponse } from "./import.worker.ts";
 import { blobs, ingestFile, primeSlots } from "./ingest.ts";
 import type { ImageEntry, StoredEntry, UserMeta } from "./metadata.ts";
+import type { ZipRequest, ZipResponse } from "./zip.worker.ts";
 import {
 	clearAll,
 	deleteEntry,
@@ -24,14 +25,18 @@ import {
 } from "./store.ts";
 
 /**
- * A bulk import's phase: `preparing` while the dropped folder tree is walked
- * (no count yet), then `adding` while files are ingested. `elapsedMs` is the
- * ingest time so far — computed here (not in render) so an indicator can derive
- * an ETA purely.
+ * A long-running library task's phase, for the top-level indicator. Import:
+ * `preparing` while the dropped folder tree is walked (no count yet), then
+ * `adding` while files are ingested. Export: `exporting` while images are read +
+ * decompressed, then `compressing` (no count) while the zip is packed.
+ * `elapsedMs` is the time so far — computed here (not in render) so an indicator
+ * can derive an ETA purely.
  */
 export type ImportProgress =
 	| { phase: "preparing" }
-	| { phase: "adding"; done: number; total: number; elapsedMs: number };
+	| { phase: "adding"; done: number; total: number; elapsedMs: number }
+	| { phase: "exporting"; done: number; total: number; elapsedMs: number }
+	| { phase: "compressing" };
 
 /**
  * Live progress of an in-flight bulk import, or null when none is running.
@@ -335,6 +340,120 @@ export function addFiles(
 			};
 			worker.onerror = () => finish({ added: 0, deduped: 0, failed: total });
 			worker.postMessage({ files, tags } satisfies ImportRequest);
+		});
+	});
+}
+
+/**
+ * Export the curated library to a `.zip` Blob: a manifest plus every
+ * non-transient image's decompressed ROM bytes under a human-friendly filename.
+ * Runs in the zip worker (the zip library lives there only); the caller triggers
+ * the download.
+ */
+export function exportLibrary(): Promise<Blob> {
+	const startedAt = performance.now();
+	importProgress.value = {
+		phase: "exporting",
+		done: 0,
+		total: 0,
+		elapsedMs: 0,
+	};
+	return new Promise<Blob>((resolve, reject) => {
+		void readyLibrary().then(() => {
+			const worker = new Worker(new URL("./zip.worker.ts", import.meta.url), {
+				type: "module",
+			});
+			const settle = (fn: () => void): void => {
+				importProgress.value = null;
+				worker.terminate();
+				fn();
+			};
+			worker.onmessage = (event: MessageEvent<ZipResponse>) => {
+				const message = event.data;
+				if (message.type === "exportProgress") {
+					importProgress.value = {
+						phase: "exporting",
+						done: message.done,
+						total: message.total,
+						elapsedMs: performance.now() - startedAt,
+					};
+				} else if (message.type === "compressing") {
+					importProgress.value = { phase: "compressing" };
+				} else if (message.type === "exported") {
+					const blob = new Blob([message.bytes as BlobPart], {
+						type: "application/zip",
+					});
+					settle(() => resolve(blob));
+				} else if (message.type === "error") {
+					settle(() => reject(new Error(message.message)));
+				}
+			};
+			worker.onerror = () =>
+				settle(() => reject(new Error("library export failed")));
+			worker.postMessage({ type: "export" } satisfies ZipRequest);
+		});
+	});
+}
+
+/**
+ * Import a previously exported library `.zip`: re-ingest each bundled ROM
+ * (recomputing hash/derived/firmware) and apply the manifest's authored
+ * metadata + built-in overrides. Mirrors {@link addFiles} — runs in the zip
+ * worker, fills the library live, and drives {@link importProgress}. Entries
+ * already present (by content hash) are deduped, not duplicated.
+ */
+export function importZip(zip: Uint8Array): Promise<BulkAddResult> {
+	const startedAt = performance.now();
+	importProgress.value = { phase: "preparing" };
+	return new Promise<BulkAddResult>((resolve) => {
+		void readyLibrary().then(() => {
+			const worker = new Worker(new URL("./zip.worker.ts", import.meta.url), {
+				type: "module",
+			});
+			const finish = (result: BulkAddResult): void => {
+				importProgress.value = null;
+				worker.terminate();
+				resolve(result);
+			};
+			worker.onmessage = async (event: MessageEvent<ZipResponse>) => {
+				const message = event.data;
+				if (message.type === "done") {
+					// Pick up any built-in overrides the worker applied to IndexedDB.
+					try {
+						const overrides = await loadOverrides();
+						builtinOverrides.value = new Map(
+							overrides.map((o) => [o.id, o.user]),
+						);
+					} catch {
+						// Overrides unavailable this session; imported images still landed.
+					}
+					finish({
+						added: message.added,
+						deduped: message.deduped,
+						failed: message.failed,
+					});
+					return;
+				}
+				if (message.type === "error") {
+					finish({ added: 0, deduped: 0, failed: 0 });
+					return;
+				}
+				if (message.type === "progress") {
+					if (message.newEntries.length > 0) {
+						userEntries.value = [...userEntries.value, ...message.newEntries];
+					}
+					importProgress.value = {
+						phase: "adding",
+						done: message.done,
+						total: message.total,
+						elapsedMs: performance.now() - startedAt,
+					};
+				}
+			};
+			worker.onerror = () => finish({ added: 0, deduped: 0, failed: 0 });
+			worker.postMessage({ type: "import", zip } satisfies ZipRequest, [
+				zip.buffer,
+			]);
 		});
 	});
 }

--- a/apps/a8-web/src/images/metadata.ts
+++ b/apps/a8-web/src/images/metadata.ts
@@ -20,6 +20,16 @@ export type DerivedMeta = ImageKind;
 /** The coarse, canonical kind of an image — what it intrinsically is. */
 export type ImageType = ImageKind["type"];
 
+/** Canonical file extension per type — a cartridge is a `.car`, an OS a raw
+ *  `.rom`, a disk an `.atr`, an executable a `.xex`. Stored names carry none;
+ *  this is added on download / library export. */
+export const CANON_EXT: Record<ImageType, string> = {
+	os: "rom",
+	cart: "car",
+	disk: "atr",
+	xex: "xex",
+};
+
 /** A slot picker an image can be surfaced in (standard-8K carts only). */
 export type ImageSlot = "basic" | "game";
 

--- a/apps/a8-web/src/images/zip.worker.ts
+++ b/apps/a8-web/src/images/zip.worker.ts
@@ -1,0 +1,228 @@
+/// <reference lib="webworker" />
+
+// Library zip export/import, off the main thread (the zip library lives here
+// only). Export: read entries + blobs from IndexedDB, decompress to real ROM
+// bytes, and pack them under human-friendly filenames alongside a manifest.
+// Import: unzip, re-ingest each ROM (recomputing hash/derived/firmware), and
+// apply the manifest's authored metadata (name/tags/slots) + built-in overrides.
+
+import { strFromU8, strToU8, unzipSync, zipSync } from "fflate";
+import { blobs, ingestFile } from "./ingest.ts";
+import { CANON_EXT } from "./metadata.ts";
+import type { ImageSlot, StoredEntry, UserMeta } from "./metadata.ts";
+import { loadEntries, loadOverrides, putOverride } from "./store.ts";
+
+const MANIFEST = "sfotty-pie-a8-library.json";
+const FLUSH_MS = 100;
+
+/** A library image's authored metadata in the manifest, linked to its file. */
+interface ManifestImage {
+	file: string;
+	name: string;
+	tags?: string[];
+	slots?: ImageSlot[];
+}
+/** A built-in's override (metadata only — the bytes are bundled), by built-in id. */
+interface ManifestOverride {
+	id: string;
+	name?: string;
+	tags?: string[];
+	slots?: ImageSlot[];
+}
+interface Manifest {
+	version: number;
+	images: ManifestImage[];
+	builtinOverrides: ManifestOverride[];
+}
+
+export type ZipRequest =
+	| { type: "export" }
+	| { type: "import"; zip: Uint8Array };
+
+export type ZipResponse =
+	| { type: "exportProgress"; done: number; total: number }
+	| { type: "compressing" }
+	| { type: "exported"; bytes: Uint8Array }
+	| {
+			type: "progress";
+			done: number;
+			total: number;
+			added: number;
+			deduped: number;
+			failed: number;
+			newEntries: StoredEntry[];
+	  }
+	| { type: "done"; added: number; deduped: number; failed: number }
+	| { type: "error"; message: string };
+
+const worker = globalThis as unknown as DedicatedWorkerGlobalScope;
+
+// A filename-safe display name (illegal characters → "_"; never empty).
+function sanitize(name: string): string {
+	// eslint-disable-next-line no-control-regex
+	return name.replace(/[/\\:*?"<>|\x00-\x1f]/g, "_").trim() || "image";
+}
+
+// A unique `name.ext`, suffixing " (2)", " (3)" … on collision (case-folded,
+// for case-insensitive filesystems).
+function uniqueName(base: string, ext: string, used: Set<string>): string {
+	let candidate = `${base}.${ext}`;
+	let n = 2;
+	while (used.has(candidate.toLowerCase()))
+		candidate = `${base} (${n++}).${ext}`;
+	used.add(candidate.toLowerCase());
+	return candidate;
+}
+
+async function exportLibrary(): Promise<Uint8Array> {
+	const [entries, overrides] = await Promise.all([
+		loadEntries(),
+		loadOverrides(),
+	]);
+	const files: Record<string, Uint8Array> = {};
+	const images: ManifestImage[] = [];
+	const used = new Set<string>();
+	const persistent = entries.filter((e) => !e.transient);
+	let done = 0;
+	let lastFlush = performance.now();
+	for (const e of persistent) {
+		const bytes = await blobs.get(e.locator.ref); // decompressed canonical ROM
+		done++;
+		if (performance.now() - lastFlush >= FLUSH_MS) {
+			worker.postMessage({
+				type: "exportProgress",
+				done,
+				total: persistent.length,
+			} satisfies ZipResponse);
+			lastFlush = performance.now();
+		}
+		if (!bytes) continue;
+		const file = uniqueName(
+			sanitize(e.user.displayName),
+			CANON_EXT[e.derived.type],
+			used,
+		);
+		files[file] = bytes;
+		images.push({
+			file,
+			name: e.user.displayName,
+			...(e.user.tags?.length && { tags: e.user.tags }),
+			...(e.user.slots?.length && { slots: e.user.slots }),
+		});
+	}
+	const builtinOverrides: ManifestOverride[] = overrides.map((o) => ({
+		id: o.id,
+		...(o.user.displayName && { name: o.user.displayName }),
+		...(o.user.tags?.length && { tags: o.user.tags }),
+		...(o.user.slots?.length && { slots: o.user.slots }),
+	}));
+	const manifest: Manifest = { version: 1, images, builtinOverrides };
+	files[MANIFEST] = strToU8(JSON.stringify(manifest, null, 2));
+	worker.postMessage({ type: "compressing" } satisfies ZipResponse);
+	return zipSync(files, { level: 6 });
+}
+
+function parseManifest(bytes: Uint8Array | undefined): Manifest | null {
+	if (!bytes) return null;
+	try {
+		const m = JSON.parse(strFromU8(bytes)) as Manifest;
+		return Array.isArray(m.images) ? m : null;
+	} catch {
+		return null;
+	}
+}
+
+async function importLibrary(zip: Uint8Array): Promise<void> {
+	const unzipped = unzipSync(zip);
+	const manifest = parseManifest(unzipped[MANIFEST]);
+	const metaByFile = new Map<string, ManifestImage>();
+	for (const img of manifest?.images ?? []) metaByFile.set(img.file, img);
+
+	const seen = new Set((await loadEntries()).map((e) => e.hash));
+	const fileNames = Object.keys(unzipped).filter((f) => f !== MANIFEST);
+	const total = fileNames.length;
+
+	let added = 0;
+	let deduped = 0;
+	let failed = 0;
+	let done = 0;
+	let batch: StoredEntry[] = [];
+	let lastFlush = performance.now();
+	const flush = (force: boolean): void => {
+		if (!force && performance.now() - lastFlush < FLUSH_MS) return;
+		worker.postMessage({
+			type: "progress",
+			done,
+			total,
+			added,
+			deduped,
+			failed,
+			newEntries: batch,
+		} satisfies ZipResponse);
+		batch = [];
+		lastFlush = performance.now();
+	};
+
+	for (const file of fileNames) {
+		const bytes = unzipped[file];
+		const m = metaByFile.get(file);
+		const meta: Partial<UserMeta> = m
+			? {
+					displayName: m.name,
+					...(m.tags && { tags: m.tags }),
+					...(m.slots && { slots: m.slots }),
+				}
+			: {};
+		const into: StoredEntry[] = [];
+		try {
+			const result = await ingestFile(bytes!, file, seen, into, false, meta);
+			added += result.added;
+			deduped += result.deduped;
+		} catch {
+			failed++; // unrecognized — canonicalize threw
+		}
+		if (into.length > 0) batch.push(...into);
+		done++;
+		flush(false);
+	}
+	flush(true);
+
+	// Apply built-in overrides, merging onto any the importing machine already has.
+	if (manifest) {
+		const existing = new Map(
+			(await loadOverrides()).map((o) => [o.id, o.user]),
+		);
+		for (const o of manifest.builtinOverrides ?? []) {
+			const user: Partial<UserMeta> = { ...existing.get(o.id) };
+			if (o.name) user.displayName = o.name;
+			if (o.tags) user.tags = o.tags;
+			if (o.slots) user.slots = o.slots;
+			await putOverride({ id: o.id, user });
+		}
+	}
+
+	worker.postMessage({
+		type: "done",
+		added,
+		deduped,
+		failed,
+	} satisfies ZipResponse);
+}
+
+worker.onmessage = async (event: MessageEvent<ZipRequest>) => {
+	try {
+		if (event.data.type === "export") {
+			const bytes = await exportLibrary();
+			worker.postMessage({ type: "exported", bytes } satisfies ZipResponse, [
+				bytes.buffer,
+			]);
+		} else {
+			await importLibrary(event.data.zip);
+		}
+	} catch (error) {
+		worker.postMessage({
+			type: "error",
+			message: error instanceof Error ? error.message : String(error),
+		} satisfies ZipResponse);
+	}
+};

--- a/apps/a8-web/src/import-progress.tsx
+++ b/apps/a8-web/src/import-progress.tsx
@@ -12,13 +12,22 @@ export function ImportProgress() {
 	const progress = importProgress.value;
 	if (!progress) return null;
 
-	const preparing = progress.phase === "preparing";
-	const pct = preparing
-		? 100
-		: Math.round((progress.done / progress.total) * 100);
-	// ETA from the rate so far (elapsed per file × files remaining).
+	// `preparing` / `compressing` are indeterminate (no count, pulsing full bar);
+	// `adding` / `exporting` are counted with an ETA.
+	const counted = progress.phase === "adding" || progress.phase === "exporting";
+	const label = {
+		preparing: messages.library.preparing,
+		adding: messages.library.adding,
+		exporting: messages.library.exporting,
+		compressing: messages.library.compressing,
+	}[progress.phase];
+	const pct =
+		counted && progress.total > 0
+			? Math.round((progress.done / progress.total) * 100)
+			: 100;
+	// ETA from the rate so far (elapsed per item × items remaining).
 	const eta =
-		!preparing && progress.done > 0
+		counted && progress.done > 0
 			? (progress.elapsedMs / 1000 / progress.done) *
 				(progress.total - progress.done)
 			: 0;
@@ -26,10 +35,8 @@ export function ImportProgress() {
 	return (
 		<div class="shrink-0 border-b border-neutral-800 bg-neutral-900 px-3 py-1 text-xs text-neutral-300">
 			<div class="flex items-center justify-between gap-2">
-				<span>
-					{preparing ? messages.library.preparing : messages.library.adding}
-				</span>
-				{!preparing && (
+				<span>{label}</span>
+				{counted && (
 					<span>
 						{progress.done} / {progress.total}
 						{eta > 0 ? ` · ${messages.library.eta(eta)}` : ""}
@@ -38,7 +45,7 @@ export function ImportProgress() {
 			</div>
 			<div class="mt-1 h-1 w-full overflow-hidden rounded bg-neutral-700">
 				<div
-					class={`h-full rounded bg-emerald-500 ${preparing ? "animate-pulse" : ""}`}
+					class={`h-full rounded bg-emerald-500 ${counted ? "" : "animate-pulse"}`}
 					style={{ width: `${pct}%` }}
 				/>
 			</div>

--- a/apps/a8-web/src/messages.ts
+++ b/apps/a8-web/src/messages.ts
@@ -149,6 +149,11 @@ export const messages = {
 		confirmClear:
 			"Clear the entire library? This removes all uploads and can't be undone.",
 		cleared: "Library cleared",
+		exportLibrary: "Export",
+		importLibrary: "Import",
+		exporting: "Exporting…",
+		compressing: "Compressing…",
+		exportFailed: "Library export failed.",
 		actions: {
 			boot: "Boot",
 			attachDisk: "Attach to D1:",

--- a/apps/a8-web/src/routes/a8/emu/library-item.page.tsx
+++ b/apps/a8-web/src/routes/a8/emu/library-item.page.tsx
@@ -13,11 +13,8 @@ import {
 	removeImage,
 	updateUserMeta,
 } from "../../../images/library.ts";
-import type {
-	ImageEntry,
-	ImageSlot,
-	ImageType,
-} from "../../../images/metadata.ts";
+import { CANON_EXT } from "../../../images/metadata.ts";
+import type { ImageEntry, ImageSlot } from "../../../images/metadata.ts";
 import { messages } from "../../../messages.ts";
 import { navigate } from "../../../navigate.ts";
 import { useEmu } from "./emu-context.ts";
@@ -49,16 +46,6 @@ function isCar(bytes: Uint8Array): boolean {
 		bytes[3] === 0x54 // T
 	);
 }
-
-// Canonical download extension per type: a cartridge is a `.car`, an OS a raw
-// `.rom`, a disk an `.atr`, an executable a `.xex`. Stored names carry no
-// extension; this is added only on download.
-const CANON_EXT: Record<ImageType, string> = {
-	os: "rom",
-	cart: "car",
-	disk: "atr",
-	xex: "xex",
-};
 
 // The per-type facts, each its own detail row (the kind itself is a separate
 // "Type" row). A cartridge resolves to its full CART_TYPES name; xex has none.

--- a/apps/a8-web/src/routes/a8/emu/library.page.tsx
+++ b/apps/a8-web/src/routes/a8/emu/library.page.tsx
@@ -4,7 +4,9 @@ import { useEffect, useMemo, useRef, useState } from "preact/hooks";
 import { Icon } from "../../../icon.tsx";
 import {
 	addFiles,
+	exportLibrary,
 	importProgress,
+	importZip,
 	libraryEntries,
 	readyLibrary,
 } from "../../../images/library.ts";
@@ -196,7 +198,9 @@ export default function LibraryPage() {
 	const { host } = useEmu();
 	const inputRef = useRef<HTMLInputElement>(null);
 	const folderInputRef = useRef<HTMLInputElement>(null);
+	const zipInputRef = useRef<HTMLInputElement>(null);
 	const [dragging, setDragging] = useState(false);
+	const [exporting, setExporting] = useState(false);
 	// Tags stamped onto everything imported next (applies to drop + both pickers).
 	const [importTags, setImportTags] = useState("");
 
@@ -250,6 +254,43 @@ export default function LibraryPage() {
 		}
 		// takes over the indicator, clears it; stamps the tags entered above
 		const result = await addFiles(files, parseTags(importTags));
+		const seconds = (performance.now() - start) / 1000;
+		host.toast(
+			messages.library.uploaded(
+				result.added,
+				result.deduped,
+				result.failed,
+				seconds,
+			),
+			result.failed > 0 ? "warning" : "info",
+		);
+	};
+
+	// Download the whole curated library as a `.zip` (manifest + ROM bytes).
+	const runExport = async (): Promise<void> => {
+		if (exporting) return;
+		setExporting(true);
+		try {
+			const blob = await exportLibrary();
+			const url = URL.createObjectURL(blob);
+			const anchor = document.createElement("a");
+			anchor.href = url;
+			anchor.download = "sfotty-pie-a8-library.zip";
+			anchor.click();
+			URL.revokeObjectURL(url);
+		} catch {
+			host.toast(messages.library.exportFailed, "warning");
+		} finally {
+			setExporting(false);
+		}
+	};
+
+	// Re-ingest a previously exported library `.zip`, applying its metadata.
+	const runZipImport = async (file: File): Promise<void> => {
+		if (importProgress.value) return; // an import is already running
+		const start = performance.now();
+		const bytes = new Uint8Array(await file.arrayBuffer());
+		const result = await importZip(bytes);
 		const seconds = (performance.now() - start) / 1000;
 		host.toast(
 			messages.library.uploaded(
@@ -619,15 +660,43 @@ export default function LibraryPage() {
 					</div>
 				)}
 
-				{hasUploads && (
+				<div class="mt-1 flex items-center gap-3 text-xs">
 					<button
 						type="button"
-						class="mt-1 self-start text-xs text-red-600 hover:underline"
-						onClick={() => host.clearLibrary()}
+						disabled={exporting}
+						class="text-neutral-600 hover:underline disabled:opacity-40"
+						onClick={() => void runExport()}
 					>
-						{messages.library.clear}
+						{messages.library.exportLibrary}
 					</button>
-				)}
+					<button
+						type="button"
+						class="text-neutral-600 hover:underline"
+						onClick={() => zipInputRef.current?.click()}
+					>
+						{messages.library.importLibrary}
+					</button>
+					{hasUploads && (
+						<button
+							type="button"
+							class="ml-auto text-red-600 hover:underline"
+							onClick={() => host.clearLibrary()}
+						>
+							{messages.library.clear}
+						</button>
+					)}
+				</div>
+				<input
+					ref={zipInputRef}
+					type="file"
+					accept=".zip"
+					class="hidden"
+					onChange={(event) => {
+						const file = event.currentTarget.files?.[0];
+						event.currentTarget.value = ""; // allow re-picking the same file
+						if (file) void runZipImport(file);
+					}}
+				/>
 			</div>
 		</PanelFrame>
 	);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@sfotty-pie/sfotty':
         specifier: workspace:*
         version: link:../../packages/sfotty
+      fflate:
+        specifier: ^0.8.3
+        version: 0.8.3
       preact:
         specifier: ^10.29.2
         version: 10.29.2
@@ -1829,6 +1832,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -4548,6 +4554,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fflate@0.8.3: {}
 
   file-entry-cache@8.0.0:
     dependencies:


### PR DESCRIPTION
Adds backup/restore + sharing of the image library as a `.zip`, with the zip library (fflate) confined to a dedicated worker so it never lands in the main bundle.

## What's in the zip
- `sfotty-pie-a8-library.json` manifest at the root — the source of truth for authored metadata (name, tags, slots) and built-in overrides.
- Every non-transient image's **decompressed** ROM bytes under a human-friendly `<name>.<ext>` filename (sanitized; collisions get ` (2)`, ` (3)`…), so the files are usable ROMs on their own.

## Export
Reads entries + built-in overrides, decompresses each blob, packs them, and downloads `sfotty-pie-a8-library.zip`.

## Import
Unzips, re-ingests each ROM (recomputing hash / derived kind / firmware) with the manifest's metadata applied, dedups by content hash, and merges built-in overrides onto any the importing machine already has. Falls back to plain ingest-by-filename when there's no manifest.

## Plumbing
- `CANON_EXT` (image-type → extension) moved to `metadata.ts`, shared by the item page and the export worker.
- `ingestFile` now takes a `meta: Partial<UserMeta>` override (manifest metadata wins over auto-derived) instead of `tags: string[]`.
- Both export and import drive the existing top-level progress indicator: `Exporting… N / M` → `Compressing…`, and `Preparing…` → `Adding… N / M`.

## UI
Export / Import actions row at the bottom of the library panel; Import opens an `accept=".zip"` picker.